### PR TITLE
Fix error in port-2-aws example docs for additional_info

### DIFF
--- a/examples/port-2-aws-connection/README.md
+++ b/examples/port-2-aws-connection/README.md
@@ -42,6 +42,7 @@ module "create_port_2_aws_connection" {
   notifications_emails  = var.notifications_emails
   bandwidth             = var.bandwidth
   purchase_order_number = var.purchase_order_number
+  additional_info       = var.additional_info
 
   # A-side
   aside_port_name      = var.aside_port_name


### PR DESCRIPTION
* Add additional_info to the list of parameters in the module example in the usage