### PR TITLE
CXF-91821 Added Oracle Test to PROD GHA

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,7 +15,7 @@ jobs:
     name: TF docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
         id: actions-checkout
         with:
           ref: main

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,7 +15,7 @@ jobs:
     name: TF docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         id: actions-checkout
         with:
           ref: main

--- a/.github/workflows/terratests-prod-suite.yaml
+++ b/.github/workflows/terratests-prod-suite.yaml
@@ -16,6 +16,7 @@ jobs:
       TEST_DATA_PROD_PORT_2_AZURE_CONNECTION: ${{ secrets.TEST_DATA_PROD_PORT_2_AZURE_CONNECTION }}
       TEST_DATA_PROD_PORT_2_GOOGLE_CONNECTION: ${{ secrets.TEST_DATA_PROD_PORT_2_GOOGLE_CONNECTION }}
       TEST_DATA_PROD_PORT_2_IBM2_CONNECTION: ${{ secrets.TEST_DATA_PROD_PORT_2_IBM2_CONNECTION }}
+      TEST_DATA_PROD_PORT_2_ORACLE_CONNECTION: ${{ secrets.TEST_DATA_PROD_PORT_2_ORACLE_CONNECTION }}
       TEST_DATA_PROD_PORT_2_PORT_CONNECTION: ${{ secrets.TEST_DATA_PROD_PORT_2_PORT_CONNECTION }}
       TEST_DATA_PROD_PORT_2_PRIVATE_SERVICE_PROFILE_CONNECTION: ${{ secrets.TEST_DATA_PROD_PORT_2_PRIVATE_SERVICE_PROFILE_CONNECTION }}
       TEST_DATA_PROD_PORT_2_WAN_CONNECTION: ${{ secrets.TEST_DATA_PROD_PORT_2_WAN_CONNECTION }}
@@ -67,6 +68,8 @@ jobs:
           jq --arg timestamp "$TIMESTAMP" '.connection_name = ($timestamp + "_" + .connection_name)' ./examples/port-2-google-connection/terraform.tfvars.json > ./examples/port-2-google-connection/tmp.test.json && mv ./examples/port-2-google-connection/tmp.test.json ./examples/port-2-google-connection/terraform.tfvars.json
           echo $TEST_DATA_PROD_PORT_2_IBM2_CONNECTION >> "./examples/port-2-ibm2-connection/terraform.tfvars.json"
           jq --arg timestamp "$TIMESTAMP$SUFFIX" '.connection_name += "" + $timestamp' ./examples/port-2-ibm2-connection/terraform.tfvars.json > ./examples/port-2-ibm2-connection/tmp.test.json && mv ./examples/port-2-ibm2-connection/tmp.test.json ./examples/port-2-ibm2-connection/terraform.tfvars.json
+          echo $TEST_DATA_PROD_PORT_2_ORACLE_CONNECTION >> "./examples/port-2-oracle-connection/terraform.tfvars.json"
+          jq --arg timestamp "$TIMESTAMP" '.connection_name = ($timestamp + "_" + .connection_name)' ./examples/port-2-oracle-connection/terraform.tfvars.json > ./examples/port-2-oracle-connection/tmp.test.json && mv ./examples/port-2-oracle-connection/tmp.test.json ./examples/port-2-oracle-connection/terraform.tfvars.json
           echo $TEST_DATA_PROD_PORT_2_PORT_CONNECTION >> "./examples/port-2-port-connection/terraform.tfvars.json"
           jq --arg timestamp "$TIMESTAMP" '.connection_name = ($timestamp + "_" + .connection_name)' ./examples/port-2-port-connection/terraform.tfvars.json > ./examples/port-2-port-connection/tmp.test.json && mv ./examples/port-2-port-connection/tmp.test.json ./examples/port-2-port-connection/terraform.tfvars.json
           echo $TEST_DATA_PROD_PORT_2_PRIVATE_SERVICE_PROFILE_CONNECTION >> "./examples/port-2-private-service-profile-connection/terraform.tfvars.json"

--- a/tests/examples-without-external-providers/cloud-router-2-aws-connection/main.tf
+++ b/tests/examples-without-external-providers/cloud-router-2-aws-connection/main.tf
@@ -4,7 +4,7 @@ provider "equinix" {
 }
 
 module "cloud_router_aws_connection" {
-  source = "equinix/fabric/equinix//modules/cloud-router-connection"
+  source = "../../../modules/cloud-router-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/examples-without-external-providers/cloud-router-2-azure-connection/main.tf
+++ b/tests/examples-without-external-providers/cloud-router-2-azure-connection/main.tf
@@ -4,7 +4,7 @@ provider "equinix" {
 }
 
 module "cloud_router_azure_connection" {
-  source = "equinix/fabric/equinix//modules/cloud-router-connection"
+  source = "../../../modules/cloud-router-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/examples-without-external-providers/cloud-router-2-port-routing-protocol-connection/main.tf
+++ b/tests/examples-without-external-providers/cloud-router-2-port-routing-protocol-connection/main.tf
@@ -1,10 +1,11 @@
 provider "equinix" {
   client_id     = var.equinix_client_id
   client_secret = var.equinix_client_secret
+  endpoint = "https://uatapi.equinix.com"
 }
 
 module "cloud_router_port_connection" {
-  source = "equinix/fabric/equinix//modules/cloud-router-connection"
+  source = "../../../modules/cloud-router-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type
@@ -25,7 +26,7 @@ module "cloud_router_port_connection" {
 
 module "routing_protocols" {
   depends_on = [module.cloud_router_port_connection]
-  source = "equinix/fabric/equinix//modules/routing-protocols"
+  source = "../../../modules/routing-protocols"
 
   connection_uuid = module.cloud_router_port_connection.primary_connection_id
 

--- a/tests/examples-without-external-providers/cloud-router-2-port-routing-protocol-connection/main.tf
+++ b/tests/examples-without-external-providers/cloud-router-2-port-routing-protocol-connection/main.tf
@@ -1,7 +1,6 @@
 provider "equinix" {
   client_id     = var.equinix_client_id
   client_secret = var.equinix_client_secret
-  endpoint = "https://uatapi.equinix.com"
 }
 
 module "cloud_router_port_connection" {

--- a/tests/examples-without-external-providers/port-2-aws-connection/main.tf
+++ b/tests/examples-without-external-providers/port-2-aws-connection/main.tf
@@ -4,7 +4,7 @@ provider "equinix" {
 }
 
 module "port_2_aws_connection" {
-  source = "equinix/fabric/equinix//modules/port-connection"
+  source = "../../../modules/port-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/examples-without-external-providers/port-2-azure-connection/main.tf
+++ b/tests/examples-without-external-providers/port-2-azure-connection/main.tf
@@ -3,7 +3,7 @@ provider "equinix" {
   client_secret = var.equinix_client_secret
 }
 module "create_port_2_azure_connection" {
-  source = "equinix/fabric/equinix//modules/port-connection"
+  source = "../../../modules/port-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/examples-without-external-providers/port-2-wan-connection/main.tf
+++ b/tests/examples-without-external-providers/port-2-wan-connection/main.tf
@@ -4,7 +4,7 @@ provider "equinix" {
 }
 
 module "create_port_2_wan_connection" {
-  source = "equinix/fabric/equinix//modules/port-connection"
+  source = "../../../modules/port-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/examples-without-external-providers/virtual-device-2-azure-connection/main.tf
+++ b/tests/examples-without-external-providers/virtual-device-2-azure-connection/main.tf
@@ -3,7 +3,7 @@ provider "equinix" {
   client_secret = var.equinix_client_secret
 }
 module "create_virtual_device_2_azure_connection" {
-  source = "equinix/fabric/equinix//modules/virtual-device-connection"
+  source = "../../../modules/virtual-device-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/examples-without-external-providers/virtual-device-2-port-connection/main.tf
+++ b/tests/examples-without-external-providers/virtual-device-2-port-connection/main.tf
@@ -3,7 +3,7 @@ provider "equinix" {
   client_secret = var.equinix_client_secret
 }
 module "create_virtual_device_2_port_connection" {
-  source = "equinix/fabric/equinix//modules/virtual-device-connection"
+  source = "../../../modules/virtual-device-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/examples-without-external-providers/virtual-device-2-wan-connection/main.tf
+++ b/tests/examples-without-external-providers/virtual-device-2-wan-connection/main.tf
@@ -4,7 +4,7 @@ provider "equinix" {
 }
 
 module "create_virtual_device_2_wan_connection" {
-  source = "equinix/fabric/equinix//modules/virtual-device-connection"
+  source = "../../../modules/virtual-device-connection"
 
   connection_name       = var.connection_name
   connection_type       = var.connection_type

--- a/tests/prod/prod_sanity_suite_test.go
+++ b/tests/prod/prod_sanity_suite_test.go
@@ -92,6 +92,20 @@ func TestPort2Ibm2CreateConnection_DIGP(t *testing.T) {
 	assert.NotNil(t, output)
 }
 
+func TestPort2OracleCreateConnection_DIGP(t *testing.T) {
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../../examples/port-2-oracle-connection",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	t.Parallel()
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "oracle_connection_id")
+	assert.NotNil(t, output)
+}
+
 func TestPort2PortCreateConnection_DIGP(t *testing.T) {
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
@@ -191,6 +205,15 @@ func TestCloudRouter2PortRoutingProtocolCreateConnection_DIGP(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 	output := terraform.Output(t, terraformOptions, "port_connection_id")
 	assert.NotNil(t, output)
+
+	terraformOptions = terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		Vars: map[string]interface{}{
+			"connection_name": "FCR2Port_Name_Update",
+			"bandwidth":       100,
+		},
+		TerraformDir: "../../tests/examples-without-external-providers/cloud-router-2-port-routing-protocol-connection",
+	})
+	terraform.Apply(t, terraformOptions)
 }
 
 func TestCloudRouter2ServiceProfileCreateConnection_DIGP(t *testing.T) {


### PR DESCRIPTION
Updated Prod GHA workflow and function by adding Oracle test case in below files
**.github/workflows/terratests-prod-suite.yaml
tests/prod/prod_sanity_suite_test.go**

Added FCR2Port Connection_name and bandwidth Upgrade in 
**tests/prod/prod_sanity_suite_test.go**

As Discussed, I have Updated Source Paths to local Paths for below resources:
**cloud-router-2-aws-connection
cloud-router-2-azure-connection
cloud-router-2-port-routing-protocol-connection
port-2-aws-connection
port-2-azure-connection
port-2-wan-connection
virtual-device-2-azure-connection
virtual-device-2-port-connection
virtual-device-2-wan-connection**