### PR TITLE
feat: Documentation Automation for Examples and Modules Contents

### DIFF
--- a/examples/service-token-metal-2-fabric-aws-connection/main.tf
+++ b/examples/service-token-metal-2-fabric-aws-connection/main.tf
@@ -9,8 +9,8 @@ provider "aws" {
   region     = var.zside_seller_region
 }
 resource "random_string" "random" {
-  length  = 3
-  special = false
+  length  = 5
+  special = true
 }
 locals {
   connection_name  = format("%s-%s", var.connection_name, random_string.random.result)


### PR DESCRIPTION
1. Updated Github actions workflow to:  

- Render Terraform docs content in examples README files
- Render Terraform docs content in modules README files
- Inline scripting to update EXAMPLE_PATH placeholder in examples README files

2. Added Terraform docs configuration files for customized README format
