### PR TITLE
CXF-98497: Fix failing GHA Docs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           message: 'Apply changes in README'
           push: false
-          new_branch: 'feature-gha-docs'
+          new_branch: feature-gha-docs-${{ github.run_id }}
 
       - name: Create Pull Request
         if: success() && steps.commit_doc_changes.outcome == 'success'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -44,6 +44,7 @@ jobs:
         run: |
           find examples -name "README.md" | while read file; do
             dir_name=$(dirname "$file")
+            echo "$dir_name"
             sed -i "s@EXAMPLE_PATH@$dir_name@g" "$file"
             sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -53,7 +53,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           message: 'Apply changes in README'
-          push: false
           new_branch: gha-docs
 
       - name: Create Pull Request

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           find examples -name "README.md" | while read file; do
             dir_name=$(dirname "$file")
-            sed -i "s@EXAMPLE_PATH@dir_name@g" "$file"
+            sed -i "s@EXAMPLE_PATH@$dir_name@g" "$file"
             sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done
 

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -54,6 +54,7 @@ jobs:
           commit_message: Apply changes in README
           branch: feature-gha-docs
           create_branch: true
+          skip_dirty_check: true
 
       - name: Create Pull Request
         if: steps.commit_doc_changes.outputs.num_changed != '0'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -53,7 +53,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           message: 'Apply changes in README'
-          new_branch: gha-docs
 
       - name: Create Pull Request
         if: success() && steps.commit_doc_changes.outcome == 'success'
@@ -65,8 +64,8 @@ jobs:
           title: 'Generate-terraform-docs: Automated action'
           body: |
             Update terraform docs
-          branch: gha-docs
           branch-suffix: timestamp
+          signoff: true
           base: main
           delete-branch: true
 

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -52,8 +52,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Apply changes in README
-          branch: feature-gha-docs
-          create_branch: true
+          branch: ""
           skip_dirty_check: true
 
       - name: Create Pull Request

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -48,14 +48,7 @@ jobs:
             sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done
 
-      - name: Auto Commit changes
-        id: commit_doc_changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: 'Apply changes in README'
-
       - name: Create Pull Request
-        if: success() && steps.commit_doc_changes.outcome == 'success'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: 'generate-terraform-docs: automated action'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -49,11 +49,12 @@ jobs:
           done
 
       - name: Auto Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        id: commit_doc_changes
+        uses: EndBug/add-and-commit@v9
         with:
-          commit_message: Apply changes in README
-          branch: ""
-          skip_dirty_check: true
+          message: 'Apply changes in README'
+          push: false
+          new_branch: 'feature-gha-docs'
 
       - name: Create Pull Request
         if: steps.commit_doc_changes.outputs.num_changed != '0'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -47,3 +47,20 @@ jobs:
             sed -i "s@EXAMPLE_PATH@dir_name@g" "$file"
             sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done
+
+      - name: Create Pull Request
+        if: steps.terraform-docs.outputs.num_changed != '0'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'generate-terraform-docs: automated action'
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: 'Generate-terraform-docs: Automated action'
+          body: |
+            Update terraform docs
+          branch: update-terraform-docs
+          branch-suffix: timestamp
+          base: main
+          delete-branch: true
+
+      # TODO(ocobleseqx): https://github.com/peter-evans/enable-pull-request-automerge

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           message: 'Apply changes in README'
           push: false
-          new_branch: feature-gha-docs-${{ github.run_id }}
+          new_branch: gha-docs
 
       - name: Create Pull Request
         if: success() && steps.commit_doc_changes.outcome == 'success'
@@ -66,7 +66,7 @@ jobs:
           title: 'Generate-terraform-docs: Automated action'
           body: |
             Update terraform docs
-          branch: feature-gha-docs
+          branch: gha-docs
           branch-suffix: timestamp
           base: main
           delete-branch: true

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -21,36 +21,31 @@ jobs:
         with:
           ref: main
 
+      - name: Install terraform-docs
+        run: |
+          curl -sSLo ./terraform-docs.tar.gz https://terraform-docs.io/dl/v0.18.0/terraform-docs-v0.18.0-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs
+          mv terraform-docs /usr/local/bin/terraform-docs
+
       - name: Render Terraform docs inside the README.md files of examples
-        id: terraform-docs-examples
-        uses: terraform-docs/gh-actions@v1.2.0
-        with:
-          config-file: templates/examples-terraform-docs.yaml
-          recursive: true
-          recursive-path: examples
-          output-file: README.md
-          args: --sort-by required
-          indention: 2
-          git-push: "false"
+        run: |
+          find examples -type d -mindepth 1 -maxdepth 1 | while read dir; do
+            terraform-docs -c "./templates/examples-terraform-docs.yaml" --output-file "README.md" "$dir"
+          done
 
       - name: Render Terraform docs inside the README.md files of modules
-        id: terraform-docs-modules
-        uses: terraform-docs/gh-actions@v1.2.0
-        with:
-          config-file: templates/modules-terraform-docs.yaml
-          recursive: true
-          recursive-path: modules
-          output-file: README.md
-          args: --sort-by required
-          indention: 2
-          git-push: "false"
+        run: |
+          find modules -type d -mindepth 1 -maxdepth 1 | while read dir; do
+            terraform-docs -c "./templates/modules-terraform-docs.yaml" --output-file "README.md" "$dir"
+          done
 
       - name: Replace EXAMPLE_PATH placeholders inside the README.md files of examples
         run: |
-          find examples -name "README.md" | while read -r file; do
-            dir_name=$(basename "$(dirname "$file")")
-            sed -i "" "s@EXAMPLE_PATH@$dir_name@g" "$file"
-            sed -i "" "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
+          find examples -name "README.md" | while read file; do
+            dir_name=$(dirname "$file")
+            sed -i "s@EXAMPLE_PATH@dir_name@g" "$file"
+            sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done
 
       # terraform-docs/gh-actions@v1.0.0 modifies .git files with owner root:root, and the following steps fail with

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -27,6 +27,8 @@ jobs:
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
           mv terraform-docs /usr/local/bin/terraform-docs
+          rm -rf terraform-docs.tar.gz
+          git restore *
 
       - name: Render Terraform docs inside the README.md files of examples
         run: |
@@ -43,8 +45,7 @@ jobs:
       - name: Replace EXAMPLE_PATH placeholders inside the README.md files of examples
         run: |
           find examples -name "README.md" | while read file; do
-            dir_name=$(dirname "$file")
-            echo "$dir_name"
+            dir_name=$(basename "$(dirname "$file")")
             sed -i "s@EXAMPLE_PATH@$dir_name@g" "$file"
             sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -47,26 +47,3 @@ jobs:
             sed -i "s@EXAMPLE_PATH@dir_name@g" "$file"
             sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done
-
-      # terraform-docs/gh-actions@v1.0.0 modifies .git files with owner root:root, and the following steps fail with
-      # insufficient permission for adding an object to repository database .git/objects
-      # since the expected user is runner:docker. See https://github.com/terraform-docs/gh-actions/issues/90
-      - name: Fix .git owner
-        run: sudo chown runner:docker -R .git
-
-      - name: Create Pull Request
-        if: steps.terraform-docs.outputs.num_changed != '0'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: 'generate-terraform-docs: automated action'
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          title: 'generate-terraform-docs: automated action'
-          body: |
-            Update terraform docs
-          branch-suffix: timestamp
-          base: main
-          signoff: true
-          delete-branch: true
-
-      # TODO(ocobleseqx): https://github.com/peter-evans/enable-pull-request-automerge

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -57,7 +57,7 @@ jobs:
           new_branch: 'feature-gha-docs'
 
       - name: Create Pull Request
-        if: steps.commit_doc_changes.outputs.num_changed != '0'
+        if: success() && steps.commit_doc_changes.outcome == 'success'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: 'generate-terraform-docs: automated action'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -48,8 +48,15 @@ jobs:
             sed -i "s@\.\.\/\.\.@equinix\/fabric\/equinix\/@" "$file"
           done
 
+      - name: Auto Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Apply changes in README
+          branch: feature-gha-docs
+          create_branch: true
+
       - name: Create Pull Request
-        if: steps.terraform-docs.outputs.num_changed != '0'
+        if: steps.commit_doc_changes.outputs.num_changed != '0'
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: 'generate-terraform-docs: automated action'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -65,7 +65,7 @@ jobs:
           title: 'Generate-terraform-docs: Automated action'
           body: |
             Update terraform docs
-          branch: update-terraform-docs
+          branch: feature-gha-docs
           branch-suffix: timestamp
           base: main
           delete-branch: true

--- a/templates/examples-terraform-docs.yaml
+++ b/templates/examples-terraform-docs.yaml
@@ -20,7 +20,7 @@ content: |-
   
   ```bash
   git clone https://github.com/equinix/terraform-equinix-fabric.git
-  cd terraform-equinix-fabric/EXAMPLE_PATH
+  cd terraform-equinix-fabric/examples/EXAMPLE_PATH
   terraform init
   terraform apply
   ```

--- a/templates/examples-terraform-docs.yaml
+++ b/templates/examples-terraform-docs.yaml
@@ -20,7 +20,7 @@ content: |-
   
   ```bash
   git clone https://github.com/equinix/terraform-equinix-fabric.git
-  cd terraform-equinix-fabric/examples/EXAMPLE_PATH
+  cd terraform-equinix-fabric/EXAMPLE_PATH
   terraform init
   terraform apply
   ```


### PR DESCRIPTION
1. Modified GHA jobs by adding scripts for running terraform-docs. My changes include four jobs-
   - Install terraform-docs
   - Render Terraform docs inside the README.md files of examples 
   - Render Terraform docs inside the README.md files of modules
   - Replace EXAMPLE_PATH placeholders inside the README.md files of examples

2. Minor changes to examples-terraform-docs.yaml config file