### PR TITLE
feat: add rp bgp_auth_key field

### DIFF
--- a/modules/cloud-router-routing-protocols/main.tf
+++ b/modules/cloud-router-routing-protocols/main.tf
@@ -24,6 +24,7 @@ resource "equinix_fabric_routing_protocol" "bgp" {
   type            = "BGP"
 
   customer_asn = var.bgp_customer_asn
+  bgp_auth_key = var.bgp_auth_key != "" ? var.bgp_auth_key : null
 
   bgp_ipv4 {
     enabled          = var.bgp_enabled_ipv4

--- a/modules/cloud-router-routing-protocols/variables.tf
+++ b/modules/cloud-router-routing-protocols/variables.tf
@@ -45,3 +45,8 @@ variable "bgp_customer_asn" {
   type        = string
   default     = ""
 }
+variable "bgp_auth_key" {
+  description = "BGP authorization key"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
AWS enables MD5 by default, so `bgp_auth_key` is mandatory to enable bgp to direct connect