### PR TITLE
CXF-104025: Remove Unused Test - CloudRouter2PortRoutingProtocol

### DIFF
--- a/tests/prod/prod_sanity_suite_test.go
+++ b/tests/prod/prod_sanity_suite_test.go
@@ -201,29 +201,6 @@ func TestCloudRouter2AzureCreateConnection_DIGP(t *testing.T) {
 	assert.NotNil(t, output)
 }
 
-func TestCloudRouter2PortRoutingProtocolCreateConnection_DIGP(t *testing.T) {
-
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../../tests/examples-without-external-providers/cloud-router-2-port-routing-protocol-connection",
-	})
-
-	defer terraform.Destroy(t, terraformOptions)
-	t.Parallel()
-
-	terraform.InitAndApply(t, terraformOptions)
-	output := terraform.Output(t, terraformOptions, "port_connection_id")
-	assert.NotNil(t, output)
-
-	terraformOptions = terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		Vars: map[string]interface{}{
-			"connection_name": "FCR2Port_Name_Update",
-			"bandwidth":       100,
-		},
-		TerraformDir: "../../tests/examples-without-external-providers/cloud-router-2-port-routing-protocol-connection",
-	})
-	terraform.Apply(t, terraformOptions)
-}
-
 func TestCloudRouter2ServiceProfileCreateConnection_DIGP(t *testing.T) {
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{


### PR DESCRIPTION
Removed test - `TestCloudRouter2PortRoutingProtocolCreateConnection_DIGP`


![image](https://github.com/user-attachments/assets/c3ab88ad-ff0b-4437-89af-3634fbe07ba4)
