### PR TITLE
feat: Add module and examples for Streaming Observability

### DIFF
--- a/.github/workflows/terratests-uat-suite.yaml
+++ b/.github/workflows/terratests-uat-suite.yaml
@@ -75,6 +75,12 @@ jobs:
       TEST_DATA_UAT_CLOUD_ROUTER_2_SERVICE_PROFILE_CONNECTION: ${{secrets.TEST_DATA_UAT_CLOUD_ROUTER_2_SERVICE_PROFILE_CONNECTION}}
       TEST_DATA_UAT_CLOUD_ROUTER_2_WAN_CONNECTION: ${{secrets.TEST_DATA_UAT_CLOUD_ROUTER_2_WAN_CONNECTION}}
       TEST_DATA_UAT_CLOUD_ROUTER_2_VIRTUAL_DEVICE_CONNECTION: ${{secrets.TEST_DATA_UAT_CLOUD_ROUTER_2_VIRTUAL_DEVICE_CONNECTION}}
+      TEST_DATA_UAT_STREAM_DATADOG_SUBSCRIPTION: ${{ secrets.TEST_DATA_UAT_STREAM_DATADOG_SUBSCRIPTION }}
+      TEST_DATA_UAT_STREAM_MSTEAMS_SUBSCRIPTION: ${{ secrets.TEST_DATA_UAT_STREAM_MSTEAMS_SUBSCRIPTION }}
+      TEST_DATA_UAT_STREAM_PAGERDUTY_SUBSCRIPTION: ${{ secrets.TEST_DATA_UAT_STREAM_PAGERDUTY_SUBSCRIPTION }}
+      TEST_DATA_UAT_STREAM_SLACK_SUBSCRIPTION: ${{ secrets.TEST_DATA_UAT_STREAM_SLACK_SUBSCRIPTION }}
+      TEST_DATA_UAT_STREAM_SPLUNK_SUBSCRIPTION: ${{ secrets.TEST_DATA_UAT_STREAM_SPLUNK_SUBSCRIPTION }}
+      TEST_DATA_UAT_STREAM_MULTIPLE_SUBSCRIPTIONS_AND_ATTACHMENT: ${{ secrets.TEST_DATA_UAT_STREAM_MULTIPLE_SUBSCRIPTIONS_AND_ATTACHMENT }}
       TEST_DATA_UAT_VIRTUAL_DEVICE_2_AWS_CONNECTION: ${{secrets.TEST_DATA_UAT_VIRTUAL_DEVICE_2_AWS_CONNECTION}}
 
     steps:
@@ -114,6 +120,14 @@ jobs:
           echo $TEST_DATA_UAT_CLOUD_ROUTER_2_WAN_CONNECTION >> "./examples/cloud-router-2-wan-connection/terraform.tfvars.json"
           echo $TEST_DATA_UAT_CLOUD_ROUTER_2_VIRTUAL_DEVICE_CONNECTION >> "./examples/cloud-router-2-virtual-device-connection/terraform.tfvars.json"
           echo $TEST_DATA_UAT_VIRTUAL_DEVICE_2_AWS_CONNECTION >> "./tests/examples-without-external-providers/virtual-device-2-aws-connection/terraform.tfvars.json"
+          
+          echo $TEST_DATA_UAT_STREAM_DATADOG_SUBSCRIPTION >> "./examples/stream-datadog-subscription/terraform.tfvars.json"
+          echo $TEST_DATA_UAT_STREAM_MSTEAMS_SUBSCRIPTION >> "./examples/stream-msteams-subscription/terraform.tfvars.json"
+          echo $TEST_DATA_UAT_STREAM_PAGERDUTY_SUBSCRIPTION >> "./examples/stream-pagerduty-subscription/terraform.tfvars.json"
+          echo $TEST_DATA_UAT_STREAM_SLACK_SUBSCRIPTION >> "./examples/stream-slack-subscription/terraform.tfvars.json"
+          echo $TEST_DATA_UAT_STREAM_SPLUNK_SUBSCRIPTION >> "./examples/stream-splunk-subscription/terraform.tfvars.json"
+          echo $TEST_DATA_UAT_STREAM_MULTIPLE_SUBSCRIPTIONS_AND_ATTACHMENT >> "./examples/stream-multiple-subscriptions-with-port-connection-attachment/terraform.tfvars.json"
+          
 
       - name: Run Go Tests
         run:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+# Ignore helper scripts
+*.sh
+*.py
+
 # Ignore IDE Files
 .idea*
 

--- a/examples/stream-datadog-subscription/README.md
+++ b/examples/stream-datadog-subscription/README.md
@@ -1,0 +1,15 @@
+# Fabric Stream and Stream Subscription - Datadog Subscription
+
+This example shows how to leverage the [Fabric Stream Module
+](https://registry.terraform.io/modules/equinix/fabric/equinix/latest/submodules/streaming-observability)
+to create a Fabric Stream and a Datadog Fabric Stream Subscription.
+
+It leverages the Equinix Terraform Provider and the Fabric Stream Module
+to set up the stream and subscription based on the parameters you have provided to
+this example. Additionally, the patterns found in this example can be followed in
+your own custom Terraform configurations for more complex solutions.
+
+See example usage below for details on how to use this example.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/examples/stream-datadog-subscription/main.tf
+++ b/examples/stream-datadog-subscription/main.tf
@@ -1,0 +1,25 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+module "stream_datadog_subscription" {
+  source = "../../modules/streaming-observability"
+
+  stream_name = var.stream_name
+  stream_description = var.stream_description
+
+  datadog_name = var.datadog_name
+  datadog_description = var.datadog_description
+  datadog_enabled = var.datadog_enabled
+  datadog_host = var.datadog_host
+  datadog_api_key = var.datadog_api_key
+  datadog_application_key = var.datadog_application_key
+  datadog_filters = var.datadog_filters
+  datadog_event_exceptions = var.datadog_event_exceptions
+  datadog_event_selections = var.datadog_event_selections
+  datadog_metric_exceptions = var.datadog_metric_exceptions
+  datadog_metric_selections = var.datadog_metric_selections
+  datadog_event_uri = var.datadog_event_uri
+  datadog_metric_uri = var.datadog_metric_uri
+}

--- a/examples/stream-datadog-subscription/main.tf
+++ b/examples/stream-datadog-subscription/main.tf
@@ -6,20 +6,20 @@ provider "equinix" {
 module "stream_datadog_subscription" {
   source = "../../modules/streaming-observability"
 
-  stream_name = var.stream_name
+  stream_name        = var.stream_name
   stream_description = var.stream_description
 
-  datadog_name = var.datadog_name
-  datadog_description = var.datadog_description
-  datadog_enabled = var.datadog_enabled
-  datadog_host = var.datadog_host
-  datadog_api_key = var.datadog_api_key
-  datadog_application_key = var.datadog_application_key
-  datadog_filters = var.datadog_filters
-  datadog_event_exceptions = var.datadog_event_exceptions
-  datadog_event_selections = var.datadog_event_selections
+  datadog_name              = var.datadog_name
+  datadog_description       = var.datadog_description
+  datadog_enabled           = var.datadog_enabled
+  datadog_host              = var.datadog_host
+  datadog_api_key           = var.datadog_api_key
+  datadog_application_key   = var.datadog_application_key
+  datadog_filters           = var.datadog_filters
+  datadog_event_exceptions  = var.datadog_event_exceptions
+  datadog_event_selections  = var.datadog_event_selections
   datadog_metric_exceptions = var.datadog_metric_exceptions
   datadog_metric_selections = var.datadog_metric_selections
-  datadog_event_uri = var.datadog_event_uri
-  datadog_metric_uri = var.datadog_metric_uri
+  datadog_event_uri         = var.datadog_event_uri
+  datadog_metric_uri        = var.datadog_metric_uri
 }

--- a/examples/stream-datadog-subscription/outputs.tf
+++ b/examples/stream-datadog-subscription/outputs.tf
@@ -1,9 +1,9 @@
 output "stream" {
-  value = module.stream_datadog_subscription.first_stream
+  value     = module.stream_datadog_subscription.first_stream
   sensitive = true
 }
 
 output "datadog_subscription" {
-  value = module.stream_datadog_subscription.datadog_subscription
+  value     = module.stream_datadog_subscription.datadog_subscription
   sensitive = true
 }

--- a/examples/stream-datadog-subscription/outputs.tf
+++ b/examples/stream-datadog-subscription/outputs.tf
@@ -1,0 +1,9 @@
+output "stream" {
+  value = module.stream_datadog_subscription.first_stream
+  sensitive = true
+}
+
+output "datadog_subscription" {
+  value = module.stream_datadog_subscription.datadog_subscription
+  sensitive = true
+}

--- a/examples/stream-datadog-subscription/terraform.tfvars.example
+++ b/examples/stream-datadog-subscription/terraform.tfvars.example
@@ -1,14 +1,14 @@
-equinix_client_id      = "<MyEquinixClientId>"
-equinix_client_secret  = "<MyEquinixSecret>"
+equinix_client_id     = "<MyEquinixClientId>"
+equinix_client_secret = "<MyEquinixSecret>"
 
-stream_name = "EmergingNetworksStream"
+stream_name        = "EmergingNetworksStream"
 stream_description = "Source for Equinix Events/Metrics/Alerts"
 
-datadog_name = "DatadogSub"
-datadog_description = "Destination for Equinix Events/Metrics/Alerts"
-datadog_enabled = true
-datadog_host = "<customer_specific_host>"
-datadog_api_key = "<datadog_api_key>"
+datadog_name            = "DatadogSub"
+datadog_description     = "Destination for Equinix Events/Metrics/Alerts"
+datadog_enabled         = true
+datadog_host            = "<customer_specific_host>"
+datadog_api_key         = "<datadog_api_key>"
 datadog_application_key = "<datadog_application_key>"
 datadog_filters = [{
   property = "/type"
@@ -17,10 +17,10 @@ datadog_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-datadog_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-datadog_event_selections = ["equinix.fabric.router.*"]
+datadog_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+datadog_event_selections  = ["equinix.fabric.router.*"]
 datadog_metric_exceptions = ["equinix.fabric.connection.*"]
 datadog_metric_selections = ["equinix.fabric.port.*"]
-datadog_event_uri = "<datadog_event_uri>"
-datadog_metric_uri = "<datadog_metric_uri>"
+datadog_event_uri         = "<datadog_event_uri>"
+datadog_metric_uri        = "<datadog_metric_uri>"
 

--- a/examples/stream-datadog-subscription/terraform.tfvars.example
+++ b/examples/stream-datadog-subscription/terraform.tfvars.example
@@ -1,0 +1,26 @@
+equinix_client_id      = "<MyEquinixClientId>"
+equinix_client_secret  = "<MyEquinixSecret>"
+
+stream_name = "EmergingNetworksStream"
+stream_description = "Source for Equinix Events/Metrics/Alerts"
+
+datadog_name = "DatadogSub"
+datadog_description = "Destination for Equinix Events/Metrics/Alerts"
+datadog_enabled = true
+datadog_host = "<customer_specific_host>"
+datadog_api_key = "<datadog_api_key>"
+datadog_application_key = "<datadog_application_key>"
+datadog_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+datadog_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+datadog_event_selections = ["equinix.fabric.router.*"]
+datadog_metric_exceptions = ["equinix.fabric.connection.*"]
+datadog_metric_selections = ["equinix.fabric.port.*"]
+datadog_event_uri = "<datadog_event_uri>"
+datadog_metric_uri = "<datadog_metric_uri>"
+

--- a/examples/stream-datadog-subscription/variables.tf
+++ b/examples/stream-datadog-subscription/variables.tf
@@ -10,82 +10,82 @@ variable "equinix_client_secret" {
 }
 variable "stream_description" {
   description = "Description of the created stream(s) in the module"
-  type = string
+  type        = string
 }
 variable "stream_name" {
   description = "Name (and name prefix) for the created stream(s) in the module"
-  type = string
+  type        = string
 }
 
 variable "datadog_api_key" {
   description = "API Key for Datadog account"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "datadog_application_key" {
   description = "Application Key for Datadog App receiving the streaming messages"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "datadog_description" {
   description = "Description of the Datadog Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_enabled" {
   description = "Boolean value enabling Datadog Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_event_uri" {
   description = "Datadog App URI for receiving streamed events"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_filters" {
   description = "Filters for the Datadog Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "datadog_host" {
   description = "Datadog Sink Hostname"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_metric_uri" {
   description = "Datadog App URI for receiving streamed metrics"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_name" {
   description = "Name of the Datadog Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }

--- a/examples/stream-datadog-subscription/variables.tf
+++ b/examples/stream-datadog-subscription/variables.tf
@@ -1,0 +1,91 @@
+variable "equinix_client_id" {
+  description = "Equinix client ID (consumer key), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "equinix_client_secret" {
+  description = "Equinix client secret ID (consumer secret), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "stream_description" {
+  description = "Description of the created stream(s) in the module"
+  type = string
+}
+variable "stream_name" {
+  description = "Name (and name prefix) for the created stream(s) in the module"
+  type = string
+}
+
+variable "datadog_api_key" {
+  description = "API Key for Datadog account"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "datadog_application_key" {
+  description = "Application Key for Datadog App receiving the streaming messages"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "datadog_description" {
+  description = "Description of the Datadog Subscription"
+  type = string
+  default = ""
+}
+variable "datadog_enabled" {
+  description = "Boolean value enabling Datadog Subscription"
+  type = string
+  default = ""
+}
+variable "datadog_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_event_uri" {
+  description = "Datadog App URI for receiving streamed events"
+  type = string
+  default = ""
+}
+variable "datadog_filters" {
+  description = "Filters for the Datadog Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "datadog_host" {
+  description = "Datadog Sink Hostname"
+  type = string
+  default = ""
+}
+variable "datadog_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_metric_uri" {
+  description = "Datadog App URI for receiving streamed metrics"
+  type = string
+  default = ""
+}
+variable "datadog_name" {
+  description = "Name of the Datadog Subscription Equinix Resource"
+  type = string
+  default = ""
+}

--- a/examples/stream-datadog-subscription/versions.tf
+++ b/examples/stream-datadog-subscription/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.4"
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 3.3.0"
+    }
+  }
+}

--- a/examples/stream-msteams-subscription/README.md
+++ b/examples/stream-msteams-subscription/README.md
@@ -1,0 +1,15 @@
+# Fabric Stream and Stream Subscription - Microsoft Teams Subscription
+
+This example shows how to leverage the [Fabric Stream Module
+](https://registry.terraform.io/modules/equinix/fabric/equinix/latest/submodules/streaming-observability)
+to create a Fabric Stream and a Microsoft Teams Fabric Stream Subscription.
+
+It leverages the Equinix Terraform Provider and the Fabric Stream Module
+to set up the stream and subscription based on the parameters you have provided to
+this example. Additionally, the patterns found in this example can be followed in
+your own custom Terraform configurations for more complex solutions.
+
+See example usage below for details on how to use this example.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/examples/stream-msteams-subscription/main.tf
+++ b/examples/stream-msteams-subscription/main.tf
@@ -6,16 +6,16 @@ provider "equinix" {
 module "stream_msteams_subscription" {
   source = "../../modules/streaming-observability"
 
-  stream_name = var.stream_name
+  stream_name        = var.stream_name
   stream_description = var.stream_description
 
-  msteams_name = var.msteams_name
-  msteams_description = var.msteams_description
-  msteams_enabled = var.msteams_enabled
-  msteams_uri = var.msteams_uri
-  msteams_filters = var.msteams_filters
-  msteams_event_exceptions = var.msteams_event_exceptions
-  msteams_event_selections = var.msteams_event_selections
+  msteams_name              = var.msteams_name
+  msteams_description       = var.msteams_description
+  msteams_enabled           = var.msteams_enabled
+  msteams_uri               = var.msteams_uri
+  msteams_filters           = var.msteams_filters
+  msteams_event_exceptions  = var.msteams_event_exceptions
+  msteams_event_selections  = var.msteams_event_selections
   msteams_metric_exceptions = var.msteams_metric_exceptions
   msteams_metric_selections = var.msteams_metric_selections
 }

--- a/examples/stream-msteams-subscription/main.tf
+++ b/examples/stream-msteams-subscription/main.tf
@@ -1,0 +1,21 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+module "stream_msteams_subscription" {
+  source = "../../modules/streaming-observability"
+
+  stream_name = var.stream_name
+  stream_description = var.stream_description
+
+  msteams_name = var.msteams_name
+  msteams_description = var.msteams_description
+  msteams_enabled = var.msteams_enabled
+  msteams_uri = var.msteams_uri
+  msteams_filters = var.msteams_filters
+  msteams_event_exceptions = var.msteams_event_exceptions
+  msteams_event_selections = var.msteams_event_selections
+  msteams_metric_exceptions = var.msteams_metric_exceptions
+  msteams_metric_selections = var.msteams_metric_selections
+}

--- a/examples/stream-msteams-subscription/outputs.tf
+++ b/examples/stream-msteams-subscription/outputs.tf
@@ -1,9 +1,9 @@
 output "stream" {
-  value = module.stream_msteams_subscription.first_stream
+  value     = module.stream_msteams_subscription.first_stream
   sensitive = true
 }
 
 output "msteams_subscription" {
-  value = module.stream_msteams_subscription.msteams_subscription
+  value     = module.stream_msteams_subscription.msteams_subscription
   sensitive = true
 }

--- a/examples/stream-msteams-subscription/outputs.tf
+++ b/examples/stream-msteams-subscription/outputs.tf
@@ -1,0 +1,9 @@
+output "stream" {
+  value = module.stream_msteams_subscription.first_stream
+  sensitive = true
+}
+
+output "msteams_subscription" {
+  value = module.stream_msteams_subscription.msteams_subscription
+  sensitive = true
+}

--- a/examples/stream-msteams-subscription/terraform.tfvars.example
+++ b/examples/stream-msteams-subscription/terraform.tfvars.example
@@ -1,0 +1,22 @@
+equinix_client_id      = "<MyEquinixClientId>"
+equinix_client_secret  = "<MyEquinixSecret>"
+
+stream_name = "EmergingNetworksStream"
+stream_description = "Source for Equinix Events/Metrics/Alerts"
+
+msteams_name = "Microsoft Teams Sub"
+msteams_description = "Destination for Equinix Events/Metrics/Alerts"
+msteams_enabled = true
+msteams_uri = "<customer_specific_uri>"
+msteams_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+msteams_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+msteams_event_selections = ["equinix.fabric.router.*"]
+msteams_metric_exceptions = ["equinix.fabric.connection.*"]
+msteams_metric_selections = ["equinix.fabric.port.*"]
+

--- a/examples/stream-msteams-subscription/terraform.tfvars.example
+++ b/examples/stream-msteams-subscription/terraform.tfvars.example
@@ -1,13 +1,13 @@
-equinix_client_id      = "<MyEquinixClientId>"
-equinix_client_secret  = "<MyEquinixSecret>"
+equinix_client_id     = "<MyEquinixClientId>"
+equinix_client_secret = "<MyEquinixSecret>"
 
-stream_name = "EmergingNetworksStream"
+stream_name        = "EmergingNetworksStream"
 stream_description = "Source for Equinix Events/Metrics/Alerts"
 
-msteams_name = "Microsoft Teams Sub"
+msteams_name        = "Microsoft Teams Sub"
 msteams_description = "Destination for Equinix Events/Metrics/Alerts"
-msteams_enabled = true
-msteams_uri = "<customer_specific_uri>"
+msteams_enabled     = true
+msteams_uri         = "<customer_specific_uri>"
 msteams_filters = [{
   property = "/type"
   operator = "LIKE"
@@ -15,8 +15,8 @@ msteams_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-msteams_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-msteams_event_selections = ["equinix.fabric.router.*"]
+msteams_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+msteams_event_selections  = ["equinix.fabric.router.*"]
 msteams_metric_exceptions = ["equinix.fabric.connection.*"]
 msteams_metric_selections = ["equinix.fabric.port.*"]
 

--- a/examples/stream-msteams-subscription/terraform.tfvars.example
+++ b/examples/stream-msteams-subscription/terraform.tfvars.example
@@ -19,4 +19,3 @@ msteams_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp
 msteams_event_selections  = ["equinix.fabric.router.*"]
 msteams_metric_exceptions = ["equinix.fabric.connection.*"]
 msteams_metric_selections = ["equinix.fabric.port.*"]
-

--- a/examples/stream-msteams-subscription/variables.tf
+++ b/examples/stream-msteams-subscription/variables.tf
@@ -10,61 +10,61 @@ variable "equinix_client_secret" {
 }
 variable "stream_description" {
   description = "Description of the created stream(s) in the module"
-  type = string
+  type        = string
 }
 variable "stream_name" {
   description = "Name (and name prefix) for the created stream(s) in the module"
-  type = string
+  type        = string
 }
 
 variable "msteams_description" {
   description = "Description of the Microsoft Teams Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "msteams_enabled" {
   description = "Boolean value enabling Microsoft Teams Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "msteams_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_filters" {
   description = "Filters for the Microsoft Teams Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "msteams_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_name" {
   description = "Name of the Microsoft Teams Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "msteams_uri" {
   description = "Microsoft Teams URI for destination of streaming messages"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }

--- a/examples/stream-msteams-subscription/variables.tf
+++ b/examples/stream-msteams-subscription/variables.tf
@@ -1,0 +1,70 @@
+variable "equinix_client_id" {
+  description = "Equinix client ID (consumer key), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "equinix_client_secret" {
+  description = "Equinix client secret ID (consumer secret), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "stream_description" {
+  description = "Description of the created stream(s) in the module"
+  type = string
+}
+variable "stream_name" {
+  description = "Name (and name prefix) for the created stream(s) in the module"
+  type = string
+}
+
+variable "msteams_description" {
+  description = "Description of the Microsoft Teams Subscription"
+  type = string
+  default = ""
+}
+variable "msteams_enabled" {
+  description = "Boolean value enabling Microsoft Teams Subscription"
+  type = string
+  default = ""
+}
+variable "msteams_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_filters" {
+  description = "Filters for the Microsoft Teams Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "msteams_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_name" {
+  description = "Name of the Microsoft Teams Subscription Equinix Resource"
+  type = string
+  default = ""
+}
+variable "msteams_uri" {
+  description = "Microsoft Teams URI for destination of streaming messages"
+  type = string
+  default = ""
+  sensitive = true
+}

--- a/examples/stream-msteams-subscription/versions.tf
+++ b/examples/stream-msteams-subscription/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.4"
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 3.3.0"
+    }
+  }
+}

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/README.md
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/README.md
@@ -1,0 +1,15 @@
+# Fabric Stream and Stream Subscription - Datadog Subscription
+
+This example shows how to leverage the [Fabric Stream Module
+](https://registry.terraform.io/modules/equinix/fabric/equinix/latest/submodules/streaming-observability)
+to create a Fabric Stream and a Datadog Fabric Stream Subscription.
+
+It leverages the Equinix Terraform Provider and the Fabric Stream Module
+to set up the stream and subscription based on the parameters you have provided to
+this example. Additionally, the patterns found in this example can be followed in
+your own custom Terraform configurations for more complex solutions.
+
+See example usage below for details on how to use this example.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/main.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/main.tf
@@ -6,69 +6,69 @@ provider "equinix" {
 module "stream_subscriptions" {
   source = "../../modules/streaming-observability"
 
-  stream_name = var.stream_name
+  stream_name        = var.stream_name
   stream_description = var.stream_description
 
-  slack_name = var.slack_name
-  slack_description = var.slack_description
-  slack_enabled = var.slack_enabled
-  slack_uri = var.slack_uri
-  slack_filters = var.slack_filters
-  slack_event_exceptions = var.slack_event_exceptions
-  slack_event_selections = var.slack_event_selections
+  slack_name              = var.slack_name
+  slack_description       = var.slack_description
+  slack_enabled           = var.slack_enabled
+  slack_uri               = var.slack_uri
+  slack_filters           = var.slack_filters
+  slack_event_exceptions  = var.slack_event_exceptions
+  slack_event_selections  = var.slack_event_selections
   slack_metric_exceptions = var.slack_metric_exceptions
   slack_metric_selections = var.slack_metric_selections
 
-  splunk_enabled = var.splunk_enabled
-  splunk_access_token = var.splunk_access_token
-  splunk_name = var.splunk_name
-  splunk_description = var.splunk_description
-  splunk_uri = var.splunk_uri
-  splunk_filters = var.splunk_filters
-  splunk_event_exceptions = var.splunk_event_exceptions
-  splunk_event_selections = var.splunk_event_exceptions
+  splunk_enabled           = var.splunk_enabled
+  splunk_access_token      = var.splunk_access_token
+  splunk_name              = var.splunk_name
+  splunk_description       = var.splunk_description
+  splunk_uri               = var.splunk_uri
+  splunk_filters           = var.splunk_filters
+  splunk_event_exceptions  = var.splunk_event_exceptions
+  splunk_event_selections  = var.splunk_event_exceptions
   splunk_metric_exceptions = var.splunk_metric_exceptions
   splunk_metric_selections = var.splunk_metric_selections
-  splunk_source = var.splunk_source
-  splunk_event_index = var.splunk_event_index
-  splunk_metric_index = var.splunk_metric_index
+  splunk_source            = var.splunk_source
+  splunk_event_index       = var.splunk_event_index
+  splunk_metric_index      = var.splunk_metric_index
 
-  msteams_name = var.msteams_name
-  msteams_description = var.msteams_description
-  msteams_enabled = var.msteams_enabled
-  msteams_uri = var.msteams_uri
-  msteams_filters = var.msteams_filters
-  msteams_event_exceptions = var.msteams_event_exceptions
-  msteams_event_selections = var.msteams_event_selections
+  msteams_name              = var.msteams_name
+  msteams_description       = var.msteams_description
+  msteams_enabled           = var.msteams_enabled
+  msteams_uri               = var.msteams_uri
+  msteams_filters           = var.msteams_filters
+  msteams_event_exceptions  = var.msteams_event_exceptions
+  msteams_event_selections  = var.msteams_event_selections
   msteams_metric_exceptions = var.msteams_metric_exceptions
   msteams_metric_selections = var.msteams_metric_selections
 
-  pagerduty_name = var.pagerduty_name
-  pagerduty_description = var.pagerduty_description
-  pagerduty_enabled = var.pagerduty_enabled
-  pagerduty_host = var.pagerduty_host
-  pagerduty_integration_key = var.pagerduty_integration_key
-  pagerduty_filters = var.pagerduty_filters
-  pagerduty_event_exceptions = var.pagerduty_event_exceptions
-  pagerduty_event_selections = var.pagerduty_event_selections
+  pagerduty_name              = var.pagerduty_name
+  pagerduty_description       = var.pagerduty_description
+  pagerduty_enabled           = var.pagerduty_enabled
+  pagerduty_host              = var.pagerduty_host
+  pagerduty_integration_key   = var.pagerduty_integration_key
+  pagerduty_filters           = var.pagerduty_filters
+  pagerduty_event_exceptions  = var.pagerduty_event_exceptions
+  pagerduty_event_selections  = var.pagerduty_event_selections
   pagerduty_metric_exceptions = var.pagerduty_metric_exceptions
   pagerduty_metric_selections = var.pagerduty_metric_selections
-  pagerduty_change_uri = var.pagerduty_change_uri
-  pagerduty_alert_uri = var.pagerduty_alert_uri
+  pagerduty_change_uri        = var.pagerduty_change_uri
+  pagerduty_alert_uri         = var.pagerduty_alert_uri
 
-  datadog_name = var.datadog_name
-  datadog_description = var.datadog_description
-  datadog_enabled = var.datadog_enabled
-  datadog_host = var.datadog_host
-  datadog_api_key = var.datadog_api_key
-  datadog_application_key = var.datadog_application_key
-  datadog_filters = var.datadog_filters
-  datadog_event_exceptions = var.datadog_event_exceptions
-  datadog_event_selections = var.datadog_event_selections
+  datadog_name              = var.datadog_name
+  datadog_description       = var.datadog_description
+  datadog_enabled           = var.datadog_enabled
+  datadog_host              = var.datadog_host
+  datadog_api_key           = var.datadog_api_key
+  datadog_application_key   = var.datadog_application_key
+  datadog_filters           = var.datadog_filters
+  datadog_event_exceptions  = var.datadog_event_exceptions
+  datadog_event_selections  = var.datadog_event_selections
   datadog_metric_exceptions = var.datadog_metric_exceptions
   datadog_metric_selections = var.datadog_metric_selections
-  datadog_event_uri = var.datadog_event_uri
-  datadog_metric_uri = var.datadog_metric_uri
+  datadog_event_uri         = var.datadog_event_uri
+  datadog_metric_uri        = var.datadog_metric_uri
 }
 
 module "create_port_2_port_connection" {
@@ -93,14 +93,14 @@ module "create_port_2_port_connection" {
 }
 
 resource "equinix_fabric_stream_attachment" "port_connection_on_stream1" {
-  asset_id = module.create_port_2_port_connection.primary_connection_id
-  asset = "connections"
+  asset_id  = module.create_port_2_port_connection.primary_connection_id
+  asset     = "connections"
   stream_id = module.stream_subscriptions.first_stream.id
 }
 
 # Second Aatachment must happen on second stream in module to handle the max subscription per stream limitation
 resource "equinix_fabric_stream_attachment" "port_connection_on_stream2" {
-  asset_id = module.create_port_2_port_connection.primary_connection_id
-  asset = "connections"
+  asset_id  = module.create_port_2_port_connection.primary_connection_id
+  asset     = "connections"
   stream_id = module.stream_subscriptions.second_stream.id
 }

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/main.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/main.tf
@@ -1,0 +1,106 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+module "stream_subscriptions" {
+  source = "../../modules/streaming-observability"
+
+  stream_name = var.stream_name
+  stream_description = var.stream_description
+
+  slack_name = var.slack_name
+  slack_description = var.slack_description
+  slack_enabled = var.slack_enabled
+  slack_uri = var.slack_uri
+  slack_filters = var.slack_filters
+  slack_event_exceptions = var.slack_event_exceptions
+  slack_event_selections = var.slack_event_selections
+  slack_metric_exceptions = var.slack_metric_exceptions
+  slack_metric_selections = var.slack_metric_selections
+
+  splunk_enabled = var.splunk_enabled
+  splunk_access_token = var.splunk_access_token
+  splunk_name = var.splunk_name
+  splunk_description = var.splunk_description
+  splunk_uri = var.splunk_uri
+  splunk_filters = var.splunk_filters
+  splunk_event_exceptions = var.splunk_event_exceptions
+  splunk_event_selections = var.splunk_event_exceptions
+  splunk_metric_exceptions = var.splunk_metric_exceptions
+  splunk_metric_selections = var.splunk_metric_selections
+  splunk_source = var.splunk_source
+  splunk_event_index = var.splunk_event_index
+  splunk_metric_index = var.splunk_metric_index
+
+  msteams_name = var.msteams_name
+  msteams_description = var.msteams_description
+  msteams_enabled = var.msteams_enabled
+  msteams_uri = var.msteams_uri
+  msteams_filters = var.msteams_filters
+  msteams_event_exceptions = var.msteams_event_exceptions
+  msteams_event_selections = var.msteams_event_selections
+  msteams_metric_exceptions = var.msteams_metric_exceptions
+  msteams_metric_selections = var.msteams_metric_selections
+
+  pagerduty_name = var.pagerduty_name
+  pagerduty_description = var.pagerduty_description
+  pagerduty_enabled = var.pagerduty_enabled
+  pagerduty_host = var.pagerduty_host
+  pagerduty_integration_key = var.pagerduty_integration_key
+  pagerduty_filters = var.pagerduty_filters
+  pagerduty_event_exceptions = var.pagerduty_event_exceptions
+  pagerduty_event_selections = var.pagerduty_event_selections
+  pagerduty_metric_exceptions = var.pagerduty_metric_exceptions
+  pagerduty_metric_selections = var.pagerduty_metric_selections
+  pagerduty_change_uri = var.pagerduty_change_uri
+  pagerduty_alert_uri = var.pagerduty_alert_uri
+
+  datadog_name = var.datadog_name
+  datadog_description = var.datadog_description
+  datadog_enabled = var.datadog_enabled
+  datadog_host = var.datadog_host
+  datadog_api_key = var.datadog_api_key
+  datadog_application_key = var.datadog_application_key
+  datadog_filters = var.datadog_filters
+  datadog_event_exceptions = var.datadog_event_exceptions
+  datadog_event_selections = var.datadog_event_selections
+  datadog_metric_exceptions = var.datadog_metric_exceptions
+  datadog_metric_selections = var.datadog_metric_selections
+  datadog_event_uri = var.datadog_event_uri
+  datadog_metric_uri = var.datadog_metric_uri
+}
+
+module "create_port_2_port_connection" {
+  source = "../../modules/port-connection"
+
+  connection_name       = var.connection_name
+  connection_type       = var.connection_type
+  notifications_type    = var.notifications_type
+  notifications_emails  = var.notifications_emails
+  bandwidth             = var.bandwidth
+  purchase_order_number = var.purchase_order_number
+
+  # A-side
+  aside_port_name = var.aside_port_name
+  aside_vlan_tag  = var.aside_vlan_tag
+
+  # Z-side
+  zside_ap_type   = var.zside_ap_type
+  zside_port_name = var.zside_port_name
+  zside_vlan_tag  = var.zside_vlan_tag
+  zside_location  = var.zside_location
+}
+
+resource "equinix_fabric_stream_attachment" "port_connection_on_stream1" {
+  asset_id = module.create_port_2_port_connection.primary_connection_id
+  asset = "connections"
+  stream_id = module.stream_subscriptions.first_stream.id
+}
+
+# Second Aatachment must happen on second stream in module to handle the max subscription per stream limitation
+resource "equinix_fabric_stream_attachment" "port_connection_on_stream2" {
+  asset_id = module.create_port_2_port_connection.primary_connection_id
+  asset = "connections"
+  stream_id = module.stream_subscriptions.second_stream.id
+}

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/outputs.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/outputs.tf
@@ -1,50 +1,50 @@
 output "first_stream" {
-  value = module.stream_subscriptions.first_stream
+  value     = module.stream_subscriptions.first_stream
   sensitive = true
 }
 
 output "second_stream" {
-  value = module.stream_subscriptions.second_stream
+  value     = module.stream_subscriptions.second_stream
   sensitive = true
 }
 
 output "splunk_subscription" {
-  value = module.stream_subscriptions.splunk_subscription
+  value     = module.stream_subscriptions.splunk_subscription
   sensitive = true
 }
 
 output "slack_subscription" {
-  value = module.stream_subscriptions.slack_subscription
+  value     = module.stream_subscriptions.slack_subscription
   sensitive = true
 }
 
 output "msteams_subscription" {
-  value = module.stream_subscriptions.msteams_subscription
+  value     = module.stream_subscriptions.msteams_subscription
   sensitive = true
 }
 
 output "pagerduty_subscription" {
-  value = module.stream_subscriptions.pagerduty_subscription
+  value     = module.stream_subscriptions.pagerduty_subscription
   sensitive = true
 }
 
 output "datadog_subscription" {
-  value = module.stream_subscriptions.datadog_subscription
+  value     = module.stream_subscriptions.datadog_subscription
   sensitive = true
 }
 
 output "port_connection" {
-  value = module.create_port_2_port_connection.primary_connection
+  value     = module.create_port_2_port_connection.primary_connection
   sensitive = true
 }
 
 output "port_attachment_on_first_stream" {
-  value = equinix_fabric_stream_attachment.port_connection_on_stream1
+  value     = equinix_fabric_stream_attachment.port_connection_on_stream1
   sensitive = true
 }
 
 output "port_attachment_on_second_stream" {
-  value = equinix_fabric_stream_attachment.port_connection_on_stream2
+  value     = equinix_fabric_stream_attachment.port_connection_on_stream2
   sensitive = true
 }
 

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/outputs.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/outputs.tf
@@ -1,0 +1,51 @@
+output "first_stream" {
+  value = module.stream_subscriptions.first_stream
+  sensitive = true
+}
+
+output "second_stream" {
+  value = module.stream_subscriptions.second_stream
+  sensitive = true
+}
+
+output "splunk_subscription" {
+  value = module.stream_subscriptions.splunk_subscription
+  sensitive = true
+}
+
+output "slack_subscription" {
+  value = module.stream_subscriptions.slack_subscription
+  sensitive = true
+}
+
+output "msteams_subscription" {
+  value = module.stream_subscriptions.msteams_subscription
+  sensitive = true
+}
+
+output "pagerduty_subscription" {
+  value = module.stream_subscriptions.pagerduty_subscription
+  sensitive = true
+}
+
+output "datadog_subscription" {
+  value = module.stream_subscriptions.datadog_subscription
+  sensitive = true
+}
+
+output "port_connection" {
+  value = module.create_port_2_port_connection.primary_connection
+  sensitive = true
+}
+
+output "port_attachment_on_first_stream" {
+  value = equinix_fabric_stream_attachment.port_connection_on_stream1
+  sensitive = true
+}
+
+output "port_attachment_on_second_stream" {
+  value = equinix_fabric_stream_attachment.port_connection_on_stream2
+  sensitive = true
+}
+
+

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/outputs.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/outputs.tf
@@ -47,5 +47,3 @@ output "port_attachment_on_second_stream" {
   value     = equinix_fabric_stream_attachment.port_connection_on_stream2
   sensitive = true
 }
-
-

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/terraform.tfvars.example
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/terraform.tfvars.example
@@ -1,0 +1,109 @@
+equinix_client_id      = "<MyEquinixClientId>"
+equinix_client_secret  = "<MyEquinixSecret>"
+
+stream_name = "EmergingNetworksStream"
+stream_description = "Source for Equinix Events/Metrics/Alerts"
+
+slack_name = "slackSub"
+slack_description = "Destination for Equinix Events/Metrics/Alerts"
+slack_enabled = true
+slack_uri = "<customer_specific_uri>"
+slack_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+slack_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+slack_event_selections = ["equinix.fabric.router.*"]
+slack_metric_exceptions = ["equinix.fabric.connection.*"]
+slack_metric_selections = ["equinix.fabric.port.*"]
+
+msteams_name = "Microsoft Teams Sub"
+msteams_description = "Destination for Equinix Events/Metrics/Alerts"
+msteams_enabled = true
+msteams_uri = "<customer_specific_uri>"
+msteams_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+msteams_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+msteams_event_selections = ["equinix.fabric.router.*"]
+msteams_metric_exceptions = ["equinix.fabric.connection.*"]
+msteams_metric_selections = ["equinix.fabric.port.*"]
+
+splunk_name = "splunkSub"
+splunk_description = "Destination for Equinix Events/Metrics/Alerts"
+splunk_enabled = true
+splunk_uri = "<customer_specific_uri>"
+splunk_access_token = "<customer_splunk_access_token"
+splunk_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+splunk_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+splunk_event_selections = ["equinix.fabric.router.*"]
+splunk_metric_exceptions = ["equinix.fabric.connection.*"]
+splunk_metric_selections = ["equinix.fabric.port.*"]
+splunk_source = "<splunk_source>"
+splunk_event_index = "<splunk_event_index>"
+splunk_metric_index = "<splunk_metric_index>"
+
+pagerduty_name = "pagerdutySub"
+pagerduty_description = "Destination for Equinix Events/Metrics/Alerts"
+pagerduty_enabled = true
+pagerduty_host = "<customer_specific_host>"
+pagerduty_integration_key = "<pagerduty_integration_key>"
+pagerduty_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+pagerduty_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+pagerduty_event_selections = ["equinix.fabric.router.*"]
+pagerduty_metric_exceptions = ["equinix.fabric.connection.*"]
+pagerduty_metric_selections = ["equinix.fabric.port.*"]
+pagerduty_change_uri = "<pagerduty_change_uri>"
+pagerduty_alert_uri = "<pagerduty_alert_uri>"
+
+datadog_name = "DatadogSub"
+datadog_description = "Destination for Equinix Events/Metrics/Alerts"
+datadog_enabled = true
+datadog_host = "<customer_specific_host>"
+datadog_api_key = "<datadog_api_key>"
+datadog_application_key = "<datadog_application_key>"
+datadog_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+datadog_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+datadog_event_selections = ["equinix.fabric.router.*"]
+datadog_metric_exceptions = ["equinix.fabric.connection.*"]
+datadog_metric_selections = ["equinix.fabric.port.*"]
+datadog_event_uri = "<datadog_event_uri>"
+datadog_metric_uri = "<datadog_metric_uri>"
+
+connection_name       = "Port2Port"
+connection_type       = "EVPL_VC"
+notifications_type    = "ALL"
+notifications_emails  = ["example@equinix.com", "test1@equinix.com"]
+bandwidth             = 50
+purchase_order_number = "1-323292"
+aside_port_name       = "ops-user100-CX-SV5-NL-Qinq-STD-1G-SEC-JP-190"
+aside_vlan_tag        = "1976"
+zside_ap_type         = "COLO"
+zside_port_name       = "ops-user100-CX-SV1-NL-Qinq-STD-1G-PRI-NK-349"
+zside_vlan_tag        = "3711"
+zside_location        = "SV"

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/terraform.tfvars.example
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/terraform.tfvars.example
@@ -1,13 +1,13 @@
-equinix_client_id      = "<MyEquinixClientId>"
-equinix_client_secret  = "<MyEquinixSecret>"
+equinix_client_id     = "<MyEquinixClientId>"
+equinix_client_secret = "<MyEquinixSecret>"
 
-stream_name = "EmergingNetworksStream"
+stream_name        = "EmergingNetworksStream"
 stream_description = "Source for Equinix Events/Metrics/Alerts"
 
-slack_name = "slackSub"
+slack_name        = "slackSub"
 slack_description = "Destination for Equinix Events/Metrics/Alerts"
-slack_enabled = true
-slack_uri = "<customer_specific_uri>"
+slack_enabled     = true
+slack_uri         = "<customer_specific_uri>"
 slack_filters = [{
   property = "/type"
   operator = "LIKE"
@@ -15,15 +15,15 @@ slack_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-slack_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-slack_event_selections = ["equinix.fabric.router.*"]
+slack_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+slack_event_selections  = ["equinix.fabric.router.*"]
 slack_metric_exceptions = ["equinix.fabric.connection.*"]
 slack_metric_selections = ["equinix.fabric.port.*"]
 
-msteams_name = "Microsoft Teams Sub"
+msteams_name        = "Microsoft Teams Sub"
 msteams_description = "Destination for Equinix Events/Metrics/Alerts"
-msteams_enabled = true
-msteams_uri = "<customer_specific_uri>"
+msteams_enabled     = true
+msteams_uri         = "<customer_specific_uri>"
 msteams_filters = [{
   property = "/type"
   operator = "LIKE"
@@ -31,15 +31,15 @@ msteams_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-msteams_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-msteams_event_selections = ["equinix.fabric.router.*"]
+msteams_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+msteams_event_selections  = ["equinix.fabric.router.*"]
 msteams_metric_exceptions = ["equinix.fabric.connection.*"]
 msteams_metric_selections = ["equinix.fabric.port.*"]
 
-splunk_name = "splunkSub"
-splunk_description = "Destination for Equinix Events/Metrics/Alerts"
-splunk_enabled = true
-splunk_uri = "<customer_specific_uri>"
+splunk_name         = "splunkSub"
+splunk_description  = "Destination for Equinix Events/Metrics/Alerts"
+splunk_enabled      = true
+splunk_uri          = "<customer_specific_uri>"
 splunk_access_token = "<customer_splunk_access_token"
 splunk_filters = [{
   property = "/type"
@@ -48,18 +48,18 @@ splunk_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-splunk_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-splunk_event_selections = ["equinix.fabric.router.*"]
+splunk_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+splunk_event_selections  = ["equinix.fabric.router.*"]
 splunk_metric_exceptions = ["equinix.fabric.connection.*"]
 splunk_metric_selections = ["equinix.fabric.port.*"]
-splunk_source = "<splunk_source>"
-splunk_event_index = "<splunk_event_index>"
-splunk_metric_index = "<splunk_metric_index>"
+splunk_source            = "<splunk_source>"
+splunk_event_index       = "<splunk_event_index>"
+splunk_metric_index      = "<splunk_metric_index>"
 
-pagerduty_name = "pagerdutySub"
-pagerduty_description = "Destination for Equinix Events/Metrics/Alerts"
-pagerduty_enabled = true
-pagerduty_host = "<customer_specific_host>"
+pagerduty_name            = "pagerdutySub"
+pagerduty_description     = "Destination for Equinix Events/Metrics/Alerts"
+pagerduty_enabled         = true
+pagerduty_host            = "<customer_specific_host>"
 pagerduty_integration_key = "<pagerduty_integration_key>"
 pagerduty_filters = [{
   property = "/type"
@@ -68,18 +68,18 @@ pagerduty_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-pagerduty_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-pagerduty_event_selections = ["equinix.fabric.router.*"]
+pagerduty_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+pagerduty_event_selections  = ["equinix.fabric.router.*"]
 pagerduty_metric_exceptions = ["equinix.fabric.connection.*"]
 pagerduty_metric_selections = ["equinix.fabric.port.*"]
-pagerduty_change_uri = "<pagerduty_change_uri>"
-pagerduty_alert_uri = "<pagerduty_alert_uri>"
+pagerduty_change_uri        = "<pagerduty_change_uri>"
+pagerduty_alert_uri         = "<pagerduty_alert_uri>"
 
-datadog_name = "DatadogSub"
-datadog_description = "Destination for Equinix Events/Metrics/Alerts"
-datadog_enabled = true
-datadog_host = "<customer_specific_host>"
-datadog_api_key = "<datadog_api_key>"
+datadog_name            = "DatadogSub"
+datadog_description     = "Destination for Equinix Events/Metrics/Alerts"
+datadog_enabled         = true
+datadog_host            = "<customer_specific_host>"
+datadog_api_key         = "<datadog_api_key>"
 datadog_application_key = "<datadog_application_key>"
 datadog_filters = [{
   property = "/type"
@@ -88,12 +88,12 @@ datadog_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-datadog_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-datadog_event_selections = ["equinix.fabric.router.*"]
+datadog_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+datadog_event_selections  = ["equinix.fabric.router.*"]
 datadog_metric_exceptions = ["equinix.fabric.connection.*"]
 datadog_metric_selections = ["equinix.fabric.port.*"]
-datadog_event_uri = "<datadog_event_uri>"
-datadog_metric_uri = "<datadog_metric_uri>"
+datadog_event_uri         = "<datadog_event_uri>"
+datadog_metric_uri        = "<datadog_metric_uri>"
 
 connection_name       = "Port2Port"
 connection_type       = "EVPL_VC"

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/variables.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/variables.tf
@@ -10,327 +10,327 @@ variable "equinix_client_secret" {
 }
 variable "stream_description" {
   description = "Description of the created stream(s) in the module"
-  type = string
+  type        = string
 }
 variable "stream_name" {
   description = "Name (and name prefix) for the created stream(s) in the module"
-  type = string
+  type        = string
 }
 
 variable "slack_uri" {
   description = "API Key for slack account"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "slack_description" {
   description = "Description of the slack Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "slack_enabled" {
   description = "Boolean value enabling slack Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "slack_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_filters" {
   description = "Filters for the slack Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "slack_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_name" {
   description = "Name of the slack Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "msteams_description" {
   description = "Description of the Microsoft Teams Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "msteams_enabled" {
   description = "Boolean value enabling Microsoft Teams Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "msteams_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_filters" {
   description = "Filters for the Microsoft Teams Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "msteams_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "msteams_name" {
   description = "Name of the Microsoft Teams Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "msteams_uri" {
   description = "Microsoft Teams URI for destination of streaming messages"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 
 variable "splunk_access_token" {
   description = "Credential for Splunk Sink Subscription"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "splunk_description" {
   description = "Description of the Splunk Equinix Subscription Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_event_index" {
   description = "Event index for the Splunk Sink Source"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_event_selections" {
   description = "Events to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_filters" {
   description = "Filters for the events and metrics on the stream subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "splunk_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_metric_index" {
   description = "Metric index for the Splunk Sink Source"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_name" {
   description = "Name of the Splunk Equinix Subscription Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_source" {
   description = "Name of the created Splunk Source for the destination of the streaming messages"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_uri" {
   description = "URI for the streaming messages to be sent to for Splunk"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_enabled" {
   description = "Boolean value indicating enablement of the Splunk Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "pagerduty_integration_key" {
   description = "Application Key for PagerDuty App receiving the streaming messages"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "pagerduty_description" {
   description = "Description of the PagerDuty Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_enabled" {
   description = "Boolean value enabling PagerDuty Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_change_uri" {
   description = "PagerDuty App URI for receiving streamed changes"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_filters" {
   description = "Filters for the PagerDuty Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "pagerduty_host" {
   description = "PagerDuty Sink Hostname"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_alert_uri" {
   description = "PagerDuty App URI for receiving streamed alerts"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_name" {
   description = "Name of the PagerDuty Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "datadog_api_key" {
   description = "API Key for Datadog account"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "datadog_application_key" {
   description = "Application Key for Datadog App receiving the streaming messages"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "datadog_description" {
   description = "Description of the Datadog Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_enabled" {
   description = "Boolean value enabling Datadog Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_event_uri" {
   description = "Datadog App URI for receiving streamed events"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_filters" {
   description = "Filters for the Datadog Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "datadog_host" {
   description = "Datadog Sink Hostname"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "datadog_metric_uri" {
   description = "Datadog App URI for receiving streamed metrics"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "datadog_name" {
   description = "Name of the Datadog Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "connection_name" {

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/variables.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/variables.tf
@@ -1,0 +1,390 @@
+variable "equinix_client_id" {
+  description = "Equinix client ID (consumer key), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "equinix_client_secret" {
+  description = "Equinix client secret ID (consumer secret), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "stream_description" {
+  description = "Description of the created stream(s) in the module"
+  type = string
+}
+variable "stream_name" {
+  description = "Name (and name prefix) for the created stream(s) in the module"
+  type = string
+}
+
+variable "slack_uri" {
+  description = "API Key for slack account"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "slack_description" {
+  description = "Description of the slack Subscription"
+  type = string
+  default = ""
+}
+variable "slack_enabled" {
+  description = "Boolean value enabling slack Subscription"
+  type = string
+  default = ""
+}
+variable "slack_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_filters" {
+  description = "Filters for the slack Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "slack_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_name" {
+  description = "Name of the slack Subscription Equinix Resource"
+  type = string
+  default = ""
+}
+
+variable "msteams_description" {
+  description = "Description of the Microsoft Teams Subscription"
+  type = string
+  default = ""
+}
+variable "msteams_enabled" {
+  description = "Boolean value enabling Microsoft Teams Subscription"
+  type = string
+  default = ""
+}
+variable "msteams_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_filters" {
+  description = "Filters for the Microsoft Teams Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "msteams_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "msteams_name" {
+  description = "Name of the Microsoft Teams Subscription Equinix Resource"
+  type = string
+  default = ""
+}
+variable "msteams_uri" {
+  description = "Microsoft Teams URI for destination of streaming messages"
+  type = string
+  default = ""
+  sensitive = true
+}
+
+variable "splunk_access_token" {
+  description = "Credential for Splunk Sink Subscription"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "splunk_description" {
+  description = "Description of the Splunk Equinix Subscription Resource"
+  type = string
+  default = ""
+}
+variable "splunk_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_event_index" {
+  description = "Event index for the Splunk Sink Source"
+  type = string
+  default = ""
+}
+variable "splunk_event_selections" {
+  description = "Events to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_filters" {
+  description = "Filters for the events and metrics on the stream subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "splunk_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_metric_index" {
+  description = "Metric index for the Splunk Sink Source"
+  type = string
+  default = ""
+}
+variable "splunk_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_name" {
+  description = "Name of the Splunk Equinix Subscription Resource"
+  type = string
+  default = ""
+}
+variable "splunk_source" {
+  description = "Name of the created Splunk Source for the destination of the streaming messages"
+  type = string
+  default = ""
+}
+variable "splunk_uri" {
+  description = "URI for the streaming messages to be sent to for Splunk"
+  type = string
+  default = ""
+}
+variable "splunk_enabled" {
+  description = "Boolean value indicating enablement of the Splunk Subscription"
+  type = string
+  default = ""
+}
+
+variable "pagerduty_integration_key" {
+  description = "Application Key for PagerDuty App receiving the streaming messages"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "pagerduty_description" {
+  description = "Description of the PagerDuty Subscription"
+  type = string
+  default = ""
+}
+variable "pagerduty_enabled" {
+  description = "Boolean value enabling PagerDuty Subscription"
+  type = string
+  default = ""
+}
+variable "pagerduty_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_change_uri" {
+  description = "PagerDuty App URI for receiving streamed changes"
+  type = string
+  default = ""
+}
+variable "pagerduty_filters" {
+  description = "Filters for the PagerDuty Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "pagerduty_host" {
+  description = "PagerDuty Sink Hostname"
+  type = string
+  default = ""
+}
+variable "pagerduty_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_alert_uri" {
+  description = "PagerDuty App URI for receiving streamed alerts"
+  type = string
+  default = ""
+}
+variable "pagerduty_name" {
+  description = "Name of the PagerDuty Subscription Equinix Resource"
+  type = string
+  default = ""
+}
+
+variable "datadog_api_key" {
+  description = "API Key for Datadog account"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "datadog_application_key" {
+  description = "Application Key for Datadog App receiving the streaming messages"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "datadog_description" {
+  description = "Description of the Datadog Subscription"
+  type = string
+  default = ""
+}
+variable "datadog_enabled" {
+  description = "Boolean value enabling Datadog Subscription"
+  type = string
+  default = ""
+}
+variable "datadog_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_event_uri" {
+  description = "Datadog App URI for receiving streamed events"
+  type = string
+  default = ""
+}
+variable "datadog_filters" {
+  description = "Filters for the Datadog Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "datadog_host" {
+  description = "Datadog Sink Hostname"
+  type = string
+  default = ""
+}
+variable "datadog_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "datadog_metric_uri" {
+  description = "Datadog App URI for receiving streamed metrics"
+  type = string
+  default = ""
+}
+variable "datadog_name" {
+  description = "Name of the Datadog Subscription Equinix Resource"
+  type = string
+  default = ""
+}
+
+variable "connection_name" {
+  description = "Connection name. An alpha-numeric 24 characters string which can include only hyphens and underscores"
+  type        = string
+}
+variable "connection_type" {
+  description = "Defines the connection type like VG_VC, EVPL_VC, EPL_VC, EC_VC, IP_VC, ACCESS_EPL_VC"
+  type        = string
+}
+variable "notifications_type" {
+  description = "Notification Type - ALL is the only type currently supported"
+  type        = string
+  default     = "ALL"
+}
+variable "notifications_emails" {
+  description = "Array of contact emails"
+  type        = list(string)
+}
+variable "bandwidth" {
+  description = "Connection bandwidth in Mbps"
+  type        = number
+}
+variable "purchase_order_number" {
+  description = "Purchase order number"
+  type        = string
+  default     = ""
+}
+variable "aside_port_name" {
+  description = "Equinix A-Side Port Name"
+  type        = string
+}
+variable "aside_vlan_tag" {
+  description = "Vlan Tag information, outer vlanSTag for QINQ connections"
+  type        = string
+}
+variable "aside_vlan_inner_tag" {
+  description = "Vlan Inner Tag information, inner vlanCTag for QINQ connections"
+  type        = string
+  default     = ""
+}
+variable "zside_ap_type" {
+  description = "Access point type - COLO, VD, VG, SP, IGW, SUBNET, GW"
+  type        = string
+}
+variable "zside_location" {
+  description = "Access point metro code"
+  type        = string
+}
+variable "zside_port_name" {
+  description = "Equinix Port Name"
+  type        = string
+}
+variable "zside_vlan_tag" {
+  description = "Vlan Tag information, outer vlanSTag for QINQ connections"
+  type        = string
+}

--- a/examples/stream-multiple-subscriptions-with-port-connection-attachment/versions.tf
+++ b/examples/stream-multiple-subscriptions-with-port-connection-attachment/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.4"
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 3.3.0"
+    }
+  }
+}

--- a/examples/stream-pagerduty-subscription/README.md
+++ b/examples/stream-pagerduty-subscription/README.md
@@ -1,0 +1,15 @@
+# Fabric Stream and Stream Subscription - PagerDuty Subscription
+
+This example shows how to leverage the [Fabric Stream Module
+](https://registry.terraform.io/modules/equinix/fabric/equinix/latest/submodules/streaming-observability)
+to create a Fabric Stream and a PagerDuty Fabric Stream Subscription.
+
+It leverages the Equinix Terraform Provider and the Fabric Stream Module
+to set up the stream and subscription based on the parameters you have provided to
+this example. Additionally, the patterns found in this example can be followed in
+your own custom Terraform configurations for more complex solutions.
+
+See example usage below for details on how to use this example.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/examples/stream-pagerduty-subscription/main.tf
+++ b/examples/stream-pagerduty-subscription/main.tf
@@ -6,19 +6,19 @@ provider "equinix" {
 module "stream_pagerduty_subscription" {
   source = "../../modules/streaming-observability"
 
-  stream_name = var.stream_name
+  stream_name        = var.stream_name
   stream_description = var.stream_description
 
-  pagerduty_name = var.pagerduty_name
-  pagerduty_description = var.pagerduty_description
-  pagerduty_enabled = var.pagerduty_enabled
-  pagerduty_host = var.pagerduty_host
-  pagerduty_integration_key = var.pagerduty_integration_key
-  pagerduty_filters = var.pagerduty_filters
-  pagerduty_event_exceptions = var.pagerduty_event_exceptions
-  pagerduty_event_selections = var.pagerduty_event_selections
+  pagerduty_name              = var.pagerduty_name
+  pagerduty_description       = var.pagerduty_description
+  pagerduty_enabled           = var.pagerduty_enabled
+  pagerduty_host              = var.pagerduty_host
+  pagerduty_integration_key   = var.pagerduty_integration_key
+  pagerduty_filters           = var.pagerduty_filters
+  pagerduty_event_exceptions  = var.pagerduty_event_exceptions
+  pagerduty_event_selections  = var.pagerduty_event_selections
   pagerduty_metric_exceptions = var.pagerduty_metric_exceptions
   pagerduty_metric_selections = var.pagerduty_metric_selections
-  pagerduty_change_uri = var.pagerduty_change_uri
-  pagerduty_alert_uri = var.pagerduty_alert_uri
+  pagerduty_change_uri        = var.pagerduty_change_uri
+  pagerduty_alert_uri         = var.pagerduty_alert_uri
 }

--- a/examples/stream-pagerduty-subscription/main.tf
+++ b/examples/stream-pagerduty-subscription/main.tf
@@ -1,0 +1,24 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+module "stream_pagerduty_subscription" {
+  source = "../../modules/streaming-observability"
+
+  stream_name = var.stream_name
+  stream_description = var.stream_description
+
+  pagerduty_name = var.pagerduty_name
+  pagerduty_description = var.pagerduty_description
+  pagerduty_enabled = var.pagerduty_enabled
+  pagerduty_host = var.pagerduty_host
+  pagerduty_integration_key = var.pagerduty_integration_key
+  pagerduty_filters = var.pagerduty_filters
+  pagerduty_event_exceptions = var.pagerduty_event_exceptions
+  pagerduty_event_selections = var.pagerduty_event_selections
+  pagerduty_metric_exceptions = var.pagerduty_metric_exceptions
+  pagerduty_metric_selections = var.pagerduty_metric_selections
+  pagerduty_change_uri = var.pagerduty_change_uri
+  pagerduty_alert_uri = var.pagerduty_alert_uri
+}

--- a/examples/stream-pagerduty-subscription/outputs.tf
+++ b/examples/stream-pagerduty-subscription/outputs.tf
@@ -1,9 +1,9 @@
 output "stream" {
-  value = module.stream_pagerduty_subscription.first_stream
+  value     = module.stream_pagerduty_subscription.first_stream
   sensitive = true
 }
 
 output "pagerduty_subscription" {
-  value = module.stream_pagerduty_subscription.pagerduty_subscription
+  value     = module.stream_pagerduty_subscription.pagerduty_subscription
   sensitive = true
 }

--- a/examples/stream-pagerduty-subscription/outputs.tf
+++ b/examples/stream-pagerduty-subscription/outputs.tf
@@ -1,0 +1,9 @@
+output "stream" {
+  value = module.stream_pagerduty_subscription.first_stream
+  sensitive = true
+}
+
+output "pagerduty_subscription" {
+  value = module.stream_pagerduty_subscription.pagerduty_subscription
+  sensitive = true
+}

--- a/examples/stream-pagerduty-subscription/terraform.tfvars.example
+++ b/examples/stream-pagerduty-subscription/terraform.tfvars.example
@@ -1,0 +1,25 @@
+equinix_client_id      = "<MyEquinixClientId>"
+equinix_client_secret  = "<MyEquinixSecret>"
+
+stream_name = "EmergingNetworksStream"
+stream_description = "Source for Equinix Events/Metrics/Alerts"
+
+pagerduty_name = "pagerdutySub"
+pagerduty_description = "Destination for Equinix Events/Metrics/Alerts"
+pagerduty_enabled = true
+pagerduty_host = "<customer_specific_host>"
+pagerduty_integration_key = "<pagerduty_integration_key>"
+pagerduty_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+pagerduty_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+pagerduty_event_selections = ["equinix.fabric.router.*"]
+pagerduty_metric_exceptions = ["equinix.fabric.connection.*"]
+pagerduty_metric_selections = ["equinix.fabric.port.*"]
+pagerduty_change_uri = "<pagerduty_change_uri>"
+pagerduty_alert_uri = "<pagerduty_alert_uri>"
+

--- a/examples/stream-pagerduty-subscription/terraform.tfvars.example
+++ b/examples/stream-pagerduty-subscription/terraform.tfvars.example
@@ -1,13 +1,13 @@
-equinix_client_id      = "<MyEquinixClientId>"
-equinix_client_secret  = "<MyEquinixSecret>"
+equinix_client_id     = "<MyEquinixClientId>"
+equinix_client_secret = "<MyEquinixSecret>"
 
-stream_name = "EmergingNetworksStream"
+stream_name        = "EmergingNetworksStream"
 stream_description = "Source for Equinix Events/Metrics/Alerts"
 
-pagerduty_name = "pagerdutySub"
-pagerduty_description = "Destination for Equinix Events/Metrics/Alerts"
-pagerduty_enabled = true
-pagerduty_host = "<customer_specific_host>"
+pagerduty_name            = "pagerdutySub"
+pagerduty_description     = "Destination for Equinix Events/Metrics/Alerts"
+pagerduty_enabled         = true
+pagerduty_host            = "<customer_specific_host>"
 pagerduty_integration_key = "<pagerduty_integration_key>"
 pagerduty_filters = [{
   property = "/type"
@@ -16,10 +16,10 @@ pagerduty_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-pagerduty_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-pagerduty_event_selections = ["equinix.fabric.router.*"]
+pagerduty_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+pagerduty_event_selections  = ["equinix.fabric.router.*"]
 pagerduty_metric_exceptions = ["equinix.fabric.connection.*"]
 pagerduty_metric_selections = ["equinix.fabric.port.*"]
-pagerduty_change_uri = "<pagerduty_change_uri>"
-pagerduty_alert_uri = "<pagerduty_alert_uri>"
+pagerduty_change_uri        = "<pagerduty_change_uri>"
+pagerduty_alert_uri         = "<pagerduty_alert_uri>"
 

--- a/examples/stream-pagerduty-subscription/variables.tf
+++ b/examples/stream-pagerduty-subscription/variables.tf
@@ -10,76 +10,76 @@ variable "equinix_client_secret" {
 }
 variable "stream_description" {
   description = "Description of the created stream(s) in the module"
-  type = string
+  type        = string
 }
 variable "stream_name" {
   description = "Name (and name prefix) for the created stream(s) in the module"
-  type = string
+  type        = string
 }
 
 variable "pagerduty_integration_key" {
   description = "Application Key for PagerDuty App receiving the streaming messages"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "pagerduty_description" {
   description = "Description of the PagerDuty Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_enabled" {
   description = "Boolean value enabling PagerDuty Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_change_uri" {
   description = "PagerDuty App URI for receiving streamed changes"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_filters" {
   description = "Filters for the PagerDuty Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "pagerduty_host" {
   description = "PagerDuty Sink Hostname"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_alert_uri" {
   description = "PagerDuty App URI for receiving streamed alerts"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "pagerduty_name" {
   description = "Name of the PagerDuty Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }

--- a/examples/stream-pagerduty-subscription/variables.tf
+++ b/examples/stream-pagerduty-subscription/variables.tf
@@ -1,0 +1,85 @@
+variable "equinix_client_id" {
+  description = "Equinix client ID (consumer key), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "equinix_client_secret" {
+  description = "Equinix client secret ID (consumer secret), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "stream_description" {
+  description = "Description of the created stream(s) in the module"
+  type = string
+}
+variable "stream_name" {
+  description = "Name (and name prefix) for the created stream(s) in the module"
+  type = string
+}
+
+variable "pagerduty_integration_key" {
+  description = "Application Key for PagerDuty App receiving the streaming messages"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "pagerduty_description" {
+  description = "Description of the PagerDuty Subscription"
+  type = string
+  default = ""
+}
+variable "pagerduty_enabled" {
+  description = "Boolean value enabling PagerDuty Subscription"
+  type = string
+  default = ""
+}
+variable "pagerduty_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_change_uri" {
+  description = "PagerDuty App URI for receiving streamed changes"
+  type = string
+  default = ""
+}
+variable "pagerduty_filters" {
+  description = "Filters for the PagerDuty Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "pagerduty_host" {
+  description = "PagerDuty Sink Hostname"
+  type = string
+  default = ""
+}
+variable "pagerduty_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "pagerduty_alert_uri" {
+  description = "PagerDuty App URI for receiving streamed alerts"
+  type = string
+  default = ""
+}
+variable "pagerduty_name" {
+  description = "Name of the PagerDuty Subscription Equinix Resource"
+  type = string
+  default = ""
+}

--- a/examples/stream-pagerduty-subscription/versions.tf
+++ b/examples/stream-pagerduty-subscription/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.4"
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 3.3.0"
+    }
+  }
+}

--- a/examples/stream-slack-subscription/README.md
+++ b/examples/stream-slack-subscription/README.md
@@ -1,0 +1,15 @@
+# Fabric Stream and Stream Subscription - Slack Subscription
+
+This example shows how to leverage the [Fabric Stream Module
+](https://registry.terraform.io/modules/equinix/fabric/equinix/latest/submodules/streaming-observability)
+to create a Fabric Stream and a Slack Fabric Stream Subscription.
+
+It leverages the Equinix Terraform Provider and the Fabric Stream Module
+to set up the stream and subscription based on the parameters you have provided to
+this example. Additionally, the patterns found in this example can be followed in
+your own custom Terraform configurations for more complex solutions.
+
+See example usage below for details on how to use this example.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/examples/stream-slack-subscription/main.tf
+++ b/examples/stream-slack-subscription/main.tf
@@ -6,16 +6,16 @@ provider "equinix" {
 module "stream_slack_subscription" {
   source = "../../modules/streaming-observability"
 
-  stream_name = var.stream_name
+  stream_name        = var.stream_name
   stream_description = var.stream_description
 
-  slack_name = var.slack_name
-  slack_description = var.slack_description
-  slack_enabled = var.slack_enabled
-  slack_uri = var.slack_uri
-  slack_filters = var.slack_filters
-  slack_event_exceptions = var.slack_event_exceptions
-  slack_event_selections = var.slack_event_selections
+  slack_name              = var.slack_name
+  slack_description       = var.slack_description
+  slack_enabled           = var.slack_enabled
+  slack_uri               = var.slack_uri
+  slack_filters           = var.slack_filters
+  slack_event_exceptions  = var.slack_event_exceptions
+  slack_event_selections  = var.slack_event_selections
   slack_metric_exceptions = var.slack_metric_exceptions
   slack_metric_selections = var.slack_metric_selections
 }

--- a/examples/stream-slack-subscription/main.tf
+++ b/examples/stream-slack-subscription/main.tf
@@ -1,0 +1,21 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+module "stream_slack_subscription" {
+  source = "../../modules/streaming-observability"
+
+  stream_name = var.stream_name
+  stream_description = var.stream_description
+
+  slack_name = var.slack_name
+  slack_description = var.slack_description
+  slack_enabled = var.slack_enabled
+  slack_uri = var.slack_uri
+  slack_filters = var.slack_filters
+  slack_event_exceptions = var.slack_event_exceptions
+  slack_event_selections = var.slack_event_selections
+  slack_metric_exceptions = var.slack_metric_exceptions
+  slack_metric_selections = var.slack_metric_selections
+}

--- a/examples/stream-slack-subscription/outputs.tf
+++ b/examples/stream-slack-subscription/outputs.tf
@@ -1,0 +1,9 @@
+output "stream" {
+  value = module.stream_slack_subscription.first_stream
+  sensitive = true
+}
+
+output "slack_subscription" {
+  value = module.stream_slack_subscription.slack_subscription
+  sensitive = true
+}

--- a/examples/stream-slack-subscription/outputs.tf
+++ b/examples/stream-slack-subscription/outputs.tf
@@ -1,9 +1,9 @@
 output "stream" {
-  value = module.stream_slack_subscription.first_stream
+  value     = module.stream_slack_subscription.first_stream
   sensitive = true
 }
 
 output "slack_subscription" {
-  value = module.stream_slack_subscription.slack_subscription
+  value     = module.stream_slack_subscription.slack_subscription
   sensitive = true
 }

--- a/examples/stream-slack-subscription/terraform.tfvars.example
+++ b/examples/stream-slack-subscription/terraform.tfvars.example
@@ -1,13 +1,13 @@
-equinix_client_id      = "<MyEquinixClientId>"
-equinix_client_secret  = "<MyEquinixSecret>"
+equinix_client_id     = "<MyEquinixClientId>"
+equinix_client_secret = "<MyEquinixSecret>"
 
-stream_name = "EmergingNetworksStream"
+stream_name        = "EmergingNetworksStream"
 stream_description = "Source for Equinix Events/Metrics/Alerts"
 
-slack_name = "slackSub"
+slack_name        = "slackSub"
 slack_description = "Destination for Equinix Events/Metrics/Alerts"
-slack_enabled = true
-slack_uri = "<customer_specific_uri>"
+slack_enabled     = true
+slack_uri         = "<customer_specific_uri>"
 slack_filters = [{
   property = "/type"
   operator = "LIKE"
@@ -15,8 +15,8 @@ slack_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-slack_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-slack_event_selections = ["equinix.fabric.router.*"]
+slack_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+slack_event_selections  = ["equinix.fabric.router.*"]
 slack_metric_exceptions = ["equinix.fabric.connection.*"]
 slack_metric_selections = ["equinix.fabric.port.*"]
 

--- a/examples/stream-slack-subscription/terraform.tfvars.example
+++ b/examples/stream-slack-subscription/terraform.tfvars.example
@@ -19,4 +19,3 @@ slack_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_c
 slack_event_selections  = ["equinix.fabric.router.*"]
 slack_metric_exceptions = ["equinix.fabric.connection.*"]
 slack_metric_selections = ["equinix.fabric.port.*"]
-

--- a/examples/stream-slack-subscription/terraform.tfvars.example
+++ b/examples/stream-slack-subscription/terraform.tfvars.example
@@ -1,0 +1,22 @@
+equinix_client_id      = "<MyEquinixClientId>"
+equinix_client_secret  = "<MyEquinixSecret>"
+
+stream_name = "EmergingNetworksStream"
+stream_description = "Source for Equinix Events/Metrics/Alerts"
+
+slack_name = "slackSub"
+slack_description = "Destination for Equinix Events/Metrics/Alerts"
+slack_enabled = true
+slack_uri = "<customer_specific_uri>"
+slack_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+slack_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+slack_event_selections = ["equinix.fabric.router.*"]
+slack_metric_exceptions = ["equinix.fabric.connection.*"]
+slack_metric_selections = ["equinix.fabric.port.*"]
+

--- a/examples/stream-slack-subscription/variables.tf
+++ b/examples/stream-slack-subscription/variables.tf
@@ -1,0 +1,70 @@
+variable "equinix_client_id" {
+  description = "Equinix client ID (consumer key), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "equinix_client_secret" {
+  description = "Equinix client secret ID (consumer secret), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "stream_description" {
+  description = "Description of the created stream(s) in the module"
+  type = string
+}
+variable "stream_name" {
+  description = "Name (and name prefix) for the created stream(s) in the module"
+  type = string
+}
+
+variable "slack_uri" {
+  description = "API Key for slack account"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "slack_description" {
+  description = "Description of the slack Subscription"
+  type = string
+  default = ""
+}
+variable "slack_enabled" {
+  description = "Boolean value enabling slack Subscription"
+  type = string
+  default = ""
+}
+variable "slack_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_event_selections" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_filters" {
+  description = "Filters for the slack Subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "slack_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "slack_name" {
+  description = "Name of the slack Subscription Equinix Resource"
+  type = string
+  default = ""
+}

--- a/examples/stream-slack-subscription/variables.tf
+++ b/examples/stream-slack-subscription/variables.tf
@@ -10,61 +10,61 @@ variable "equinix_client_secret" {
 }
 variable "stream_description" {
   description = "Description of the created stream(s) in the module"
-  type = string
+  type        = string
 }
 variable "stream_name" {
   description = "Name (and name prefix) for the created stream(s) in the module"
-  type = string
+  type        = string
 }
 
 variable "slack_uri" {
   description = "API Key for slack account"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "slack_description" {
   description = "Description of the slack Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "slack_enabled" {
   description = "Boolean value enabling slack Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "slack_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_event_selections" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_filters" {
   description = "Filters for the slack Subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "slack_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "slack_name" {
   description = "Name of the slack Subscription Equinix Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }

--- a/examples/stream-slack-subscription/versions.tf
+++ b/examples/stream-slack-subscription/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.4"
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 3.3.0"
+    }
+  }
+}

--- a/examples/stream-splunk-subscription/README.md
+++ b/examples/stream-splunk-subscription/README.md
@@ -1,0 +1,15 @@
+# Fabric Stream and Stream Subscription - Splunk Subscription
+
+This example shows how to leverage the [Fabric Stream Module
+](https://registry.terraform.io/modules/equinix/fabric/equinix/latest/submodules/streaming-observability)
+to create a Fabric Stream and a Splunk Fabric Stream Subscription.
+
+It leverages the Equinix Terraform Provider and the Fabric Stream Module
+to set up the stream and subscription based on the parameters you have provided to
+this example. Additionally, the patterns found in this example can be followed in
+your own custom Terraform configurations for more complex solutions.
+
+See example usage below for details on how to use this example.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/examples/stream-splunk-subscription/main.tf
+++ b/examples/stream-splunk-subscription/main.tf
@@ -6,20 +6,20 @@ provider "equinix" {
 module "stream_splunk_subscription" {
   source = "../../modules/streaming-observability"
 
-  stream_name = var.stream_name
+  stream_name        = var.stream_name
   stream_description = var.stream_description
 
-  splunk_enabled = var.splunk_enabled
-  splunk_access_token = var.splunk_access_token
-  splunk_name = var.splunk_name
-  splunk_description = var.splunk_description
-  splunk_uri = var.splunk_uri
-  splunk_filters = var.splunk_filters
-  splunk_event_exceptions = var.splunk_event_exceptions
-  splunk_event_selections = var.splunk_event_exceptions
+  splunk_enabled           = var.splunk_enabled
+  splunk_access_token      = var.splunk_access_token
+  splunk_name              = var.splunk_name
+  splunk_description       = var.splunk_description
+  splunk_uri               = var.splunk_uri
+  splunk_filters           = var.splunk_filters
+  splunk_event_exceptions  = var.splunk_event_exceptions
+  splunk_event_selections  = var.splunk_event_exceptions
   splunk_metric_exceptions = var.splunk_metric_exceptions
   splunk_metric_selections = var.splunk_metric_selections
-  splunk_source = var.splunk_source
-  splunk_event_index = var.splunk_event_index
-  splunk_metric_index = var.splunk_metric_index
+  splunk_source            = var.splunk_source
+  splunk_event_index       = var.splunk_event_index
+  splunk_metric_index      = var.splunk_metric_index
 }

--- a/examples/stream-splunk-subscription/main.tf
+++ b/examples/stream-splunk-subscription/main.tf
@@ -1,0 +1,25 @@
+provider "equinix" {
+  client_id     = var.equinix_client_id
+  client_secret = var.equinix_client_secret
+}
+
+module "stream_splunk_subscription" {
+  source = "../../modules/streaming-observability"
+
+  stream_name = var.stream_name
+  stream_description = var.stream_description
+
+  splunk_enabled = var.splunk_enabled
+  splunk_access_token = var.splunk_access_token
+  splunk_name = var.splunk_name
+  splunk_description = var.splunk_description
+  splunk_uri = var.splunk_uri
+  splunk_filters = var.splunk_filters
+  splunk_event_exceptions = var.splunk_event_exceptions
+  splunk_event_selections = var.splunk_event_exceptions
+  splunk_metric_exceptions = var.splunk_metric_exceptions
+  splunk_metric_selections = var.splunk_metric_selections
+  splunk_source = var.splunk_source
+  splunk_event_index = var.splunk_event_index
+  splunk_metric_index = var.splunk_metric_index
+}

--- a/examples/stream-splunk-subscription/outputs.tf
+++ b/examples/stream-splunk-subscription/outputs.tf
@@ -1,0 +1,9 @@
+output "stream" {
+  value = module.stream_splunk_subscription.first_stream
+  sensitive = true
+}
+
+output "splunk_subscription" {
+  value = module.stream_splunk_subscription.splunk_subscription
+  sensitive = true
+}

--- a/examples/stream-splunk-subscription/outputs.tf
+++ b/examples/stream-splunk-subscription/outputs.tf
@@ -1,9 +1,9 @@
 output "stream" {
-  value = module.stream_splunk_subscription.first_stream
+  value     = module.stream_splunk_subscription.first_stream
   sensitive = true
 }
 
 output "splunk_subscription" {
-  value = module.stream_splunk_subscription.splunk_subscription
+  value     = module.stream_splunk_subscription.splunk_subscription
   sensitive = true
 }

--- a/examples/stream-splunk-subscription/terraform.tfvars.example
+++ b/examples/stream-splunk-subscription/terraform.tfvars.example
@@ -23,4 +23,3 @@ splunk_metric_selections = ["equinix.fabric.port.*"]
 splunk_source            = "<splunk_source>"
 splunk_event_index       = "<splunk_event_index>"
 splunk_metric_index      = "<splunk_metric_index>"
-

--- a/examples/stream-splunk-subscription/terraform.tfvars.example
+++ b/examples/stream-splunk-subscription/terraform.tfvars.example
@@ -1,13 +1,13 @@
-equinix_client_id      = "<MyEquinixClientId>"
-equinix_client_secret  = "<MyEquinixSecret>"
+equinix_client_id     = "<MyEquinixClientId>"
+equinix_client_secret = "<MyEquinixSecret>"
 
-stream_name = "EmergingNetworksStream"
+stream_name        = "EmergingNetworksStream"
 stream_description = "Source for Equinix Events/Metrics/Alerts"
 
-splunk_name = "splunkSub"
-splunk_description = "Destination for Equinix Events/Metrics/Alerts"
-splunk_enabled = true
-splunk_uri = "<customer_specific_uri>"
+splunk_name         = "splunkSub"
+splunk_description  = "Destination for Equinix Events/Metrics/Alerts"
+splunk_enabled      = true
+splunk_uri          = "<customer_specific_uri>"
 splunk_access_token = "<customer_splunk_access_token"
 splunk_filters = [{
   property = "/type"
@@ -16,11 +16,11 @@ splunk_filters = [{
     "equinix.fabric.connection%"
   ]
 }]
-splunk_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
-splunk_event_selections = ["equinix.fabric.router.*"]
+splunk_event_exceptions  = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+splunk_event_selections  = ["equinix.fabric.router.*"]
 splunk_metric_exceptions = ["equinix.fabric.connection.*"]
 splunk_metric_selections = ["equinix.fabric.port.*"]
-splunk_source = "<splunk_source>"
-splunk_event_index = "<splunk_event_index>"
-splunk_metric_index = "<splunk_metric_index>"
+splunk_source            = "<splunk_source>"
+splunk_event_index       = "<splunk_event_index>"
+splunk_metric_index      = "<splunk_metric_index>"
 

--- a/examples/stream-splunk-subscription/terraform.tfvars.example
+++ b/examples/stream-splunk-subscription/terraform.tfvars.example
@@ -1,0 +1,26 @@
+equinix_client_id      = "<MyEquinixClientId>"
+equinix_client_secret  = "<MyEquinixSecret>"
+
+stream_name = "EmergingNetworksStream"
+stream_description = "Source for Equinix Events/Metrics/Alerts"
+
+splunk_name = "splunkSub"
+splunk_description = "Destination for Equinix Events/Metrics/Alerts"
+splunk_enabled = true
+splunk_uri = "<customer_specific_uri>"
+splunk_access_token = "<customer_splunk_access_token"
+splunk_filters = [{
+  property = "/type"
+  operator = "LIKE"
+  values = [
+    "equinix.fabric.connection%"
+  ]
+}]
+splunk_event_exceptions = ["equinix.fabric.connection.route_filter.pending_bgp_configuration"]
+splunk_event_selections = ["equinix.fabric.router.*"]
+splunk_metric_exceptions = ["equinix.fabric.connection.*"]
+splunk_metric_selections = ["equinix.fabric.port.*"]
+splunk_source = "<splunk_source>"
+splunk_event_index = "<splunk_event_index>"
+splunk_metric_index = "<splunk_metric_index>"
+

--- a/examples/stream-splunk-subscription/variables.tf
+++ b/examples/stream-splunk-subscription/variables.tf
@@ -11,80 +11,80 @@ variable "equinix_client_secret" {
 
 variable "splunk_access_token" {
   description = "Credential for Splunk Sink Subscription"
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "splunk_description" {
   description = "Description of the Splunk Equinix Subscription Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_event_exceptions" {
   description = "Events to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_event_index" {
   description = "Event index for the Splunk Sink Source"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_event_selections" {
   description = "Events to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_filters" {
   description = "Filters for the events and metrics on the stream subscription"
-  type        = list(object({
+  type = list(object({
     property = string,
     operator = string,
-    values = list(string),
-    or = optional(bool),
+    values   = list(string),
+    or       = optional(bool),
   }))
   default = []
 }
 variable "splunk_metric_exceptions" {
   description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_metric_index" {
   description = "Metric index for the Splunk Sink Source"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_metric_selections" {
   description = "Metrics to include from the possibilities available to the stream for the Subscription"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 variable "splunk_name" {
   description = "Name of the Splunk Equinix Subscription Resource"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_source" {
   description = "Name of the created Splunk Source for the destination of the streaming messages"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_uri" {
   description = "URI for the streaming messages to be sent to for Splunk"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "splunk_enabled" {
   description = "Boolean value indicating enablement of the Splunk Subscription"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 variable "stream_description" {
   description = "Description of the created stream(s) in the module"
-  type = string
+  type        = string
 }
 variable "stream_name" {
   description = "Name (and name prefix) for the created stream(s) in the module"
-  type = string
+  type        = string
 }

--- a/examples/stream-splunk-subscription/variables.tf
+++ b/examples/stream-splunk-subscription/variables.tf
@@ -1,0 +1,90 @@
+variable "equinix_client_id" {
+  description = "Equinix client ID (consumer key), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+variable "equinix_client_secret" {
+  description = "Equinix client secret ID (consumer secret), obtained after registering app in the developer platform"
+  type        = string
+  sensitive   = true
+}
+
+variable "splunk_access_token" {
+  description = "Credential for Splunk Sink Subscription"
+  type = string
+  default = ""
+  sensitive = true
+}
+variable "splunk_description" {
+  description = "Description of the Splunk Equinix Subscription Resource"
+  type = string
+  default = ""
+}
+variable "splunk_event_exceptions" {
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_event_index" {
+  description = "Event index for the Splunk Sink Source"
+  type = string
+  default = ""
+}
+variable "splunk_event_selections" {
+  description = "Events to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_filters" {
+  description = "Filters for the events and metrics on the stream subscription"
+  type        = list(object({
+    property = string,
+    operator = string,
+    values = list(string),
+    or = optional(bool),
+  }))
+  default = []
+}
+variable "splunk_metric_exceptions" {
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_metric_index" {
+  description = "Metric index for the Splunk Sink Source"
+  type = string
+  default = ""
+}
+variable "splunk_metric_selections" {
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type = list(string)
+  default = []
+}
+variable "splunk_name" {
+  description = "Name of the Splunk Equinix Subscription Resource"
+  type = string
+  default = ""
+}
+variable "splunk_source" {
+  description = "Name of the created Splunk Source for the destination of the streaming messages"
+  type = string
+  default = ""
+}
+variable "splunk_uri" {
+  description = "URI for the streaming messages to be sent to for Splunk"
+  type = string
+  default = ""
+}
+variable "splunk_enabled" {
+  description = "Boolean value indicating enablement of the Splunk Subscription"
+  type = string
+  default = ""
+}
+variable "stream_description" {
+  description = "Description of the created stream(s) in the module"
+  type = string
+}
+variable "stream_name" {
+  description = "Name (and name prefix) for the created stream(s) in the module"
+  type = string
+}

--- a/examples/stream-splunk-subscription/versions.tf
+++ b/examples/stream-splunk-subscription/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.4"
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 3.3.0"
+    }
+  }
+}

--- a/modules/streaming-observability/README.md
+++ b/modules/streaming-observability/README.md
@@ -1,0 +1,21 @@
+# Fabric Streaming Observability SubModule
+
+The Fabric Streaming Observability Module will:
+1. Create a Fabric Stream
+   * **NOTE: Fabric streams have a max limit of 3 subscriptions per stream.
+     So if all subscriptions available in this module are leveraged then a 
+     2nd Fabric Stream will be created to accommodate the extra subscriptions.
+     This does have billing considerations to take into account as the 2nd
+     Fabric Stream will be billed to your account as well**
+2. Create Fabric Stream Subscriptions based on the variable values input into
+   the module at creation
+   * Available subscription types in this module at this time are:
+     [Splunk, Slack, MicrosoftTeams, PagerDuty, Datadog]
+3. Exposes outputs for each of the Fabric Resources created in this module
+   * View outputs.tf file below for details on how the resource outputs are
+     provided based on their creation
+
+Please refer to the stream* examples in this module's registry for more details on how to leverage the submodule.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/modules/streaming-observability/main.tf
+++ b/modules/streaming-observability/main.tf
@@ -1,0 +1,167 @@
+
+# Conditional logic determining if a second stream should be created to allow for the total count of subscriptions
+locals {
+  number_of_subscriptions = [
+    for sub in [var.splunk_uri, var.slack_uri, var.pagerduty_host, var.msteams_uri, var.datadog_host] : sub if sub != ""
+  ]
+  second_stream = length(local.number_of_subscriptions) > 3 ? true : false
+}
+
+
+# Stream Creation -----------------------------------------------------
+resource "equinix_fabric_stream" "stream1" {
+  type = "TELEMETRY_STREAM"
+  name = var.stream_name
+  description = var.stream_description
+}
+
+resource "equinix_fabric_stream" "stream2" {
+  count = local.second_stream ? 1 : 0
+  type = "TELEMETRY_STREAM"
+  name = join("-", [var.stream_name, "2"])
+  description = var.stream_description
+}
+
+# Stream Subscription for Splunk --------------------------------------
+resource "equinix_fabric_stream_subscription" "splunk" {
+  count = var.splunk_uri != "" ? 1 : 0
+  type = "STREAM_SUBSCRIPTION"
+  name = var.splunk_name
+  description = var.splunk_description
+  stream_id = equinix_fabric_stream.stream1.id
+  enabled = var.splunk_enabled
+  filters = var.splunk_filters != [] ? var.splunk_filters : null
+  event_selector = {
+    include = var.splunk_event_selections != [] ? var.splunk_event_selections : null
+    except = var.splunk_event_exceptions != [] ? var.splunk_event_exceptions : null
+  }
+  metric_selector = {
+    include = var.splunk_metric_selections != [] ? var.splunk_metric_selections : null
+    except = var.splunk_metric_exceptions != [] ? var.splunk_metric_exceptions : null
+  }
+  sink = {
+    type = "SPLUNK_HEC"
+    uri = var.splunk_uri
+    settings = {
+      source = var.splunk_source
+      event_index  = var.splunk_event_index
+      metric_index = var.splunk_metric_index
+    }
+    credential = {
+      type = "ACCESS_TOKEN"
+      access_token = var.splunk_access_token
+    }
+  }
+}
+
+# Stream Subscription for Slack --------------------------------------
+resource "equinix_fabric_stream_subscription" "slack" {
+  count = var.slack_uri != "" ? 1 : 0
+  type = "STREAM_SUBSCRIPTION"
+  name = var.slack_name
+  description = var.slack_description
+  stream_id = equinix_fabric_stream.stream1.id
+  enabled = var.slack_enabled
+  filters = var.slack_filters != [] ? var.slack_filters : null
+  event_selector = {
+    include = var.slack_event_selections != [] ? var.slack_event_selections : null
+    except = var.slack_event_exceptions != [] ? var.slack_event_exceptions : null
+  }
+  metric_selector = {
+    include = var.slack_metric_selections != [] ? var.slack_metric_selections : null
+    except = var.slack_metric_exceptions != [] ? var.slack_metric_exceptions : null
+  }
+  sink = {
+    type = "SLACK"
+    uri = var.slack_uri
+  }
+}
+
+# Stream Subscription for Pager Duty --------------------------------------
+resource "equinix_fabric_stream_subscription" "pagerduty" {
+  count = var.pagerduty_host != "" ? 1 : 0
+  type = "STREAM_SUBSCRIPTION"
+  name = var.pagerduty_name
+  description = var.pagerduty_description
+  stream_id = equinix_fabric_stream.stream1.id
+  enabled = var.pagerduty_enabled
+  filters = var.pagerduty_filters != [] ? var.pagerduty_filters : null
+  event_selector = {
+    include = var.pagerduty_event_selections != [] ? var.pagerduty_event_selections : null
+    except = var.pagerduty_event_exceptions != [] ? var.pagerduty_event_exceptions : null
+  }
+  metric_selector = {
+    include = var.pagerduty_metric_selections != [] ? var.pagerduty_metric_selections : null
+    except = var.pagerduty_metric_exceptions != [] ? var.pagerduty_metric_exceptions : null
+  }
+  sink = {
+    type = "PAGERDUTY"
+    host = var.pagerduty_host
+    settings = {
+      change_uri = var.pagerduty_change_uri
+      alert_uri = var.pagerduty_alert_uri
+    }
+    credential = {
+      type = "INTEGRATION_KEY"
+      integration_key = var.pagerduty_integration_key
+    }
+  }
+}
+
+# Stream Subscription for DataDog --------------------------------------
+resource "equinix_fabric_stream_subscription" "datadog" {
+  count = var.datadog_host != "" ? 1 : 0
+  type = "STREAM_SUBSCRIPTION"
+  name = var.datadog_name
+  description = var.datadog_description
+  stream_id = local.second_stream ? equinix_fabric_stream.stream2[0].id : equinix_fabric_stream.stream1.id
+  enabled = var.datadog_enabled
+  filters = var.datadog_filters != [] ? var.datadog_filters : null
+  event_selector = {
+    include = var.datadog_event_selections != [] ? var.datadog_event_selections : null
+    except = var.datadog_event_exceptions != [] ? var.datadog_event_exceptions : null
+  }
+  metric_selector = {
+    include = var.datadog_metric_selections != [] ? var.datadog_metric_selections : null
+    except = var.datadog_metric_exceptions != [] ? var.datadog_metric_exceptions : null
+  }
+  sink = {
+    type = "DATADOG"
+    host = var.datadog_host
+    settings = {
+      source = "Equinix"
+      application_key = var.datadog_application_key
+      event_uri = var.datadog_event_uri
+      metric_uri = var.datadog_metric_uri
+    }
+    credential = {
+      type = "API_KEY"
+      api_key = var.datadog_api_key
+    }
+  }
+}
+
+# Stream Subscription for Microsoft Teams --------------------------------------
+resource "equinix_fabric_stream_subscription" "msteams" {
+  count = var.msteams_uri != "" ? 1 : 0
+  type = "STREAM_SUBSCRIPTION"
+  name = var.msteams_name
+  description = var.msteams_description
+  stream_id = local.second_stream ? equinix_fabric_stream.stream2[0].id : equinix_fabric_stream.stream1.id
+  enabled = var.msteams_enabled
+  filters = var.msteams_filters != [] ? var.msteams_filters : null
+  event_selector = {
+    include = var.msteams_event_selections != [] ? var.msteams_event_selections : null
+    except = var.msteams_event_exceptions != [] ? var.msteams_event_exceptions : null
+  }
+  metric_selector = {
+    include = var.msteams_metric_selections != [] ? var.msteams_metric_selections : null
+    except = var.msteams_metric_exceptions != [] ? var.msteams_metric_exceptions : null
+  }
+  sink = {
+    type = "TEAMS"
+    uri = var.msteams_uri
+  }
+}
+
+

--- a/modules/streaming-observability/main.tf
+++ b/modules/streaming-observability/main.tf
@@ -10,45 +10,45 @@ locals {
 
 # Stream Creation -----------------------------------------------------
 resource "equinix_fabric_stream" "stream1" {
-  type = "TELEMETRY_STREAM"
-  name = var.stream_name
+  type        = "TELEMETRY_STREAM"
+  name        = var.stream_name
   description = var.stream_description
 }
 
 resource "equinix_fabric_stream" "stream2" {
-  count = local.second_stream ? 1 : 0
-  type = "TELEMETRY_STREAM"
-  name = join("-", [var.stream_name, "2"])
+  count       = local.second_stream ? 1 : 0
+  type        = "TELEMETRY_STREAM"
+  name        = join("-", [var.stream_name, "2"])
   description = var.stream_description
 }
 
 # Stream Subscription for Splunk --------------------------------------
 resource "equinix_fabric_stream_subscription" "splunk" {
-  count = var.splunk_uri != "" ? 1 : 0
-  type = "STREAM_SUBSCRIPTION"
-  name = var.splunk_name
+  count       = var.splunk_uri != "" ? 1 : 0
+  type        = "STREAM_SUBSCRIPTION"
+  name        = var.splunk_name
   description = var.splunk_description
-  stream_id = equinix_fabric_stream.stream1.id
-  enabled = var.splunk_enabled
-  filters = var.splunk_filters != [] ? var.splunk_filters : null
+  stream_id   = equinix_fabric_stream.stream1.id
+  enabled     = var.splunk_enabled
+  filters     = var.splunk_filters != [] ? var.splunk_filters : null
   event_selector = {
     include = var.splunk_event_selections != [] ? var.splunk_event_selections : null
-    except = var.splunk_event_exceptions != [] ? var.splunk_event_exceptions : null
+    except  = var.splunk_event_exceptions != [] ? var.splunk_event_exceptions : null
   }
   metric_selector = {
     include = var.splunk_metric_selections != [] ? var.splunk_metric_selections : null
-    except = var.splunk_metric_exceptions != [] ? var.splunk_metric_exceptions : null
+    except  = var.splunk_metric_exceptions != [] ? var.splunk_metric_exceptions : null
   }
   sink = {
     type = "SPLUNK_HEC"
-    uri = var.splunk_uri
+    uri  = var.splunk_uri
     settings = {
-      source = var.splunk_source
+      source       = var.splunk_source
       event_index  = var.splunk_event_index
       metric_index = var.splunk_metric_index
     }
     credential = {
-      type = "ACCESS_TOKEN"
+      type         = "ACCESS_TOKEN"
       access_token = var.splunk_access_token
     }
   }
@@ -56,53 +56,53 @@ resource "equinix_fabric_stream_subscription" "splunk" {
 
 # Stream Subscription for Slack --------------------------------------
 resource "equinix_fabric_stream_subscription" "slack" {
-  count = var.slack_uri != "" ? 1 : 0
-  type = "STREAM_SUBSCRIPTION"
-  name = var.slack_name
+  count       = var.slack_uri != "" ? 1 : 0
+  type        = "STREAM_SUBSCRIPTION"
+  name        = var.slack_name
   description = var.slack_description
-  stream_id = equinix_fabric_stream.stream1.id
-  enabled = var.slack_enabled
-  filters = var.slack_filters != [] ? var.slack_filters : null
+  stream_id   = equinix_fabric_stream.stream1.id
+  enabled     = var.slack_enabled
+  filters     = var.slack_filters != [] ? var.slack_filters : null
   event_selector = {
     include = var.slack_event_selections != [] ? var.slack_event_selections : null
-    except = var.slack_event_exceptions != [] ? var.slack_event_exceptions : null
+    except  = var.slack_event_exceptions != [] ? var.slack_event_exceptions : null
   }
   metric_selector = {
     include = var.slack_metric_selections != [] ? var.slack_metric_selections : null
-    except = var.slack_metric_exceptions != [] ? var.slack_metric_exceptions : null
+    except  = var.slack_metric_exceptions != [] ? var.slack_metric_exceptions : null
   }
   sink = {
     type = "SLACK"
-    uri = var.slack_uri
+    uri  = var.slack_uri
   }
 }
 
 # Stream Subscription for Pager Duty --------------------------------------
 resource "equinix_fabric_stream_subscription" "pagerduty" {
-  count = var.pagerduty_host != "" ? 1 : 0
-  type = "STREAM_SUBSCRIPTION"
-  name = var.pagerduty_name
+  count       = var.pagerduty_host != "" ? 1 : 0
+  type        = "STREAM_SUBSCRIPTION"
+  name        = var.pagerduty_name
   description = var.pagerduty_description
-  stream_id = equinix_fabric_stream.stream1.id
-  enabled = var.pagerduty_enabled
-  filters = var.pagerduty_filters != [] ? var.pagerduty_filters : null
+  stream_id   = equinix_fabric_stream.stream1.id
+  enabled     = var.pagerduty_enabled
+  filters     = var.pagerduty_filters != [] ? var.pagerduty_filters : null
   event_selector = {
     include = var.pagerduty_event_selections != [] ? var.pagerduty_event_selections : null
-    except = var.pagerduty_event_exceptions != [] ? var.pagerduty_event_exceptions : null
+    except  = var.pagerduty_event_exceptions != [] ? var.pagerduty_event_exceptions : null
   }
   metric_selector = {
     include = var.pagerduty_metric_selections != [] ? var.pagerduty_metric_selections : null
-    except = var.pagerduty_metric_exceptions != [] ? var.pagerduty_metric_exceptions : null
+    except  = var.pagerduty_metric_exceptions != [] ? var.pagerduty_metric_exceptions : null
   }
   sink = {
     type = "PAGERDUTY"
     host = var.pagerduty_host
     settings = {
       change_uri = var.pagerduty_change_uri
-      alert_uri = var.pagerduty_alert_uri
+      alert_uri  = var.pagerduty_alert_uri
     }
     credential = {
-      type = "INTEGRATION_KEY"
+      type            = "INTEGRATION_KEY"
       integration_key = var.pagerduty_integration_key
     }
   }
@@ -110,32 +110,32 @@ resource "equinix_fabric_stream_subscription" "pagerduty" {
 
 # Stream Subscription for DataDog --------------------------------------
 resource "equinix_fabric_stream_subscription" "datadog" {
-  count = var.datadog_host != "" ? 1 : 0
-  type = "STREAM_SUBSCRIPTION"
-  name = var.datadog_name
+  count       = var.datadog_host != "" ? 1 : 0
+  type        = "STREAM_SUBSCRIPTION"
+  name        = var.datadog_name
   description = var.datadog_description
-  stream_id = local.second_stream ? equinix_fabric_stream.stream2[0].id : equinix_fabric_stream.stream1.id
-  enabled = var.datadog_enabled
-  filters = var.datadog_filters != [] ? var.datadog_filters : null
+  stream_id   = local.second_stream ? equinix_fabric_stream.stream2[0].id : equinix_fabric_stream.stream1.id
+  enabled     = var.datadog_enabled
+  filters     = var.datadog_filters != [] ? var.datadog_filters : null
   event_selector = {
     include = var.datadog_event_selections != [] ? var.datadog_event_selections : null
-    except = var.datadog_event_exceptions != [] ? var.datadog_event_exceptions : null
+    except  = var.datadog_event_exceptions != [] ? var.datadog_event_exceptions : null
   }
   metric_selector = {
     include = var.datadog_metric_selections != [] ? var.datadog_metric_selections : null
-    except = var.datadog_metric_exceptions != [] ? var.datadog_metric_exceptions : null
+    except  = var.datadog_metric_exceptions != [] ? var.datadog_metric_exceptions : null
   }
   sink = {
     type = "DATADOG"
     host = var.datadog_host
     settings = {
-      source = "Equinix"
+      source          = "Equinix"
       application_key = var.datadog_application_key
-      event_uri = var.datadog_event_uri
-      metric_uri = var.datadog_metric_uri
+      event_uri       = var.datadog_event_uri
+      metric_uri      = var.datadog_metric_uri
     }
     credential = {
-      type = "API_KEY"
+      type    = "API_KEY"
       api_key = var.datadog_api_key
     }
   }
@@ -143,24 +143,24 @@ resource "equinix_fabric_stream_subscription" "datadog" {
 
 # Stream Subscription for Microsoft Teams --------------------------------------
 resource "equinix_fabric_stream_subscription" "msteams" {
-  count = var.msteams_uri != "" ? 1 : 0
-  type = "STREAM_SUBSCRIPTION"
-  name = var.msteams_name
+  count       = var.msteams_uri != "" ? 1 : 0
+  type        = "STREAM_SUBSCRIPTION"
+  name        = var.msteams_name
   description = var.msteams_description
-  stream_id = local.second_stream ? equinix_fabric_stream.stream2[0].id : equinix_fabric_stream.stream1.id
-  enabled = var.msteams_enabled
-  filters = var.msteams_filters != [] ? var.msteams_filters : null
+  stream_id   = local.second_stream ? equinix_fabric_stream.stream2[0].id : equinix_fabric_stream.stream1.id
+  enabled     = var.msteams_enabled
+  filters     = var.msteams_filters != [] ? var.msteams_filters : null
   event_selector = {
     include = var.msteams_event_selections != [] ? var.msteams_event_selections : null
-    except = var.msteams_event_exceptions != [] ? var.msteams_event_exceptions : null
+    except  = var.msteams_event_exceptions != [] ? var.msteams_event_exceptions : null
   }
   metric_selector = {
     include = var.msteams_metric_selections != [] ? var.msteams_metric_selections : null
-    except = var.msteams_metric_exceptions != [] ? var.msteams_metric_exceptions : null
+    except  = var.msteams_metric_exceptions != [] ? var.msteams_metric_exceptions : null
   }
   sink = {
     type = "TEAMS"
-    uri = var.msteams_uri
+    uri  = var.msteams_uri
   }
 }
 

--- a/modules/streaming-observability/outputs.tf
+++ b/modules/streaming-observability/outputs.tf
@@ -1,0 +1,34 @@
+output "first_stream" {
+  value = equinix_fabric_stream.stream1
+  sensitive = true
+}
+
+output "second_stream" {
+  value = local.second_stream ? equinix_fabric_stream.stream2[0] : null
+  sensitive = true
+}
+
+output "splunk_subscription" {
+  value = var.splunk_uri != "" ? equinix_fabric_stream_subscription.splunk[0] : null
+  sensitive = true
+}
+
+output "slack_subscription" {
+  value = var.slack_uri != "" ? equinix_fabric_stream_subscription.slack[0] : null
+  sensitive = true
+}
+
+output "msteams_subscription" {
+  value = var.msteams_uri != "" ? equinix_fabric_stream_subscription.msteams[0] : null
+  sensitive = true
+}
+
+output "pagerduty_subscription" {
+  value = var.pagerduty_host != "" ? equinix_fabric_stream_subscription.pagerduty[0] : null
+  sensitive = true
+}
+
+output "datadog_subscription" {
+  value = var.datadog_host != "" ? equinix_fabric_stream_subscription.datadog[0] : null
+  sensitive = true
+}

--- a/modules/streaming-observability/outputs.tf
+++ b/modules/streaming-observability/outputs.tf
@@ -1,34 +1,34 @@
 output "first_stream" {
-  value = equinix_fabric_stream.stream1
+  value     = equinix_fabric_stream.stream1
   sensitive = true
 }
 
 output "second_stream" {
-  value = local.second_stream ? equinix_fabric_stream.stream2[0] : null
+  value     = local.second_stream ? equinix_fabric_stream.stream2[0] : null
   sensitive = true
 }
 
 output "splunk_subscription" {
-  value = var.splunk_uri != "" ? equinix_fabric_stream_subscription.splunk[0] : null
+  value     = var.splunk_uri != "" ? equinix_fabric_stream_subscription.splunk[0] : null
   sensitive = true
 }
 
 output "slack_subscription" {
-  value = var.slack_uri != "" ? equinix_fabric_stream_subscription.slack[0] : null
+  value     = var.slack_uri != "" ? equinix_fabric_stream_subscription.slack[0] : null
   sensitive = true
 }
 
 output "msteams_subscription" {
-  value = var.msteams_uri != "" ? equinix_fabric_stream_subscription.msteams[0] : null
+  value     = var.msteams_uri != "" ? equinix_fabric_stream_subscription.msteams[0] : null
   sensitive = true
 }
 
 output "pagerduty_subscription" {
-  value = var.pagerduty_host != "" ? equinix_fabric_stream_subscription.pagerduty[0] : null
+  value     = var.pagerduty_host != "" ? equinix_fabric_stream_subscription.pagerduty[0] : null
   sensitive = true
 }
 
 output "datadog_subscription" {
-  value = var.datadog_host != "" ? equinix_fabric_stream_subscription.datadog[0] : null
+  value     = var.datadog_host != "" ? equinix_fabric_stream_subscription.datadog[0] : null
   sensitive = true
 }

--- a/modules/streaming-observability/variables.tf
+++ b/modules/streaming-observability/variables.tf
@@ -1,320 +1,320 @@
 
 variable "datadog_api_key" {
-	description = "API Key for Datadog account"
-	type = string
-	default = ""
-	sensitive = true
+  description = "API Key for Datadog account"
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "datadog_application_key" {
-	description = "Application Key for Datadog App receiving the streaming messages"
-	type = string
-	default = ""
-	sensitive = true
+  description = "Application Key for Datadog App receiving the streaming messages"
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "datadog_description" {
-	description = "Description of the Datadog Subscription"
-	type = string
-	default = ""
+  description = "Description of the Datadog Subscription"
+  type        = string
+  default     = ""
 }
 variable "datadog_enabled" {
-	description = "Boolean value enabling Datadog Subscription"
-	type = string
-	default = ""
+  description = "Boolean value enabling Datadog Subscription"
+  type        = string
+  default     = ""
 }
 variable "datadog_event_exceptions" {
-	description = "Events to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "datadog_event_selections" {
-	description = "Events to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "datadog_event_uri" {
-	description = "Datadog App URI for receiving streamed events"
-	type = string
-	default = ""
+  description = "Datadog App URI for receiving streamed events"
+  type        = string
+  default     = ""
 }
 variable "datadog_filters" {
-	description = "Filters for the Datadog Subscription"
-	type        = list(object({
-		property = string,
-		operator = string,
-		values = list(string),
-		or = optional(bool),
-	}))
-	default = []
+  description = "Filters for the Datadog Subscription"
+  type = list(object({
+    property = string,
+    operator = string,
+    values   = list(string),
+    or       = optional(bool),
+  }))
+  default = []
 }
 variable "datadog_host" {
-	description = "Datadog Sink Hostname"
-	type = string
-	default = ""
+  description = "Datadog Sink Hostname"
+  type        = string
+  default     = ""
 }
 variable "datadog_metric_exceptions" {
-	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "datadog_metric_selections" {
-	description = "Metrics to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "datadog_metric_uri" {
-	description = "Datadog App URI for receiving streamed metrics"
-	type = string
-	default = ""
+  description = "Datadog App URI for receiving streamed metrics"
+  type        = string
+  default     = ""
 }
 variable "datadog_name" {
-	description = "Name of the Datadog Subscription Equinix Resource"
-	type = string
-	default = ""
+  description = "Name of the Datadog Subscription Equinix Resource"
+  type        = string
+  default     = ""
 }
 variable "msteams_description" {
-	description = "Description for the MSTeams Subscription Resource"
-	type = string
-	default = ""
+  description = "Description for the MSTeams Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "msteams_enabled" {
-	description = "Boolean value enabling MSTeams Sink Subscription"
-	type = string
-	default = ""
+  description = "Boolean value enabling MSTeams Sink Subscription"
+  type        = string
+  default     = ""
 }
 variable "msteams_event_exceptions" {
-	description = "Events to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "msteams_event_selections" {
-	description = "Events to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "msteams_filters" {
-	description = "Filters for the events and metrics on the stream subscription"
-	type        = list(object({
-		property = string,
-		operator = string,
-		values = list(string),
-		or = optional(bool),
-	}))
-	default = []
+  description = "Filters for the events and metrics on the stream subscription"
+  type = list(object({
+    property = string,
+    operator = string,
+    values   = list(string),
+    or       = optional(bool),
+  }))
+  default = []
 }
 variable "msteams_metric_exceptions" {
-	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "msteams_metric_selections" {
-	description = "Metrics to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "msteams_name" {
-	description = "Name of the MSTeams Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Name of the MSTeams Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "msteams_uri" {
-	description = "URI that the streaming messages will be sent to for MSTeams"
-	type = string
-	default = ""
-	sensitive = true
+  description = "URI that the streaming messages will be sent to for MSTeams"
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "pagerduty_alert_uri" {
-	description = "URI for the streaming alerts to be sent to for PagerDuty"
-	type = string
-	default = ""
+  description = "URI for the streaming alerts to be sent to for PagerDuty"
+  type        = string
+  default     = ""
 }
 variable "pagerduty_change_uri" {
-	description = "URI for the streaming events to be sent to for PagerDuty"
-	type = string
-	default = ""
+  description = "URI for the streaming events to be sent to for PagerDuty"
+  type        = string
+  default     = ""
 }
 variable "pagerduty_description" {
-	description = "Description of the PagerDuty Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Description of the PagerDuty Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "pagerduty_enabled" {
-	description = "Boolean value indicating enablment for the PagerDuty Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Boolean value indicating enablment for the PagerDuty Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "pagerduty_event_exceptions" {
-	description = "Events to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_event_selections" {
-	description = "Events to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_filters" {
-	description = "Filters for the events and metrics on the stream subscription"
-	type        = list(object({
-		property = string,
-		operator = string,
-		values = list(string),
-		or = optional(bool),
-	}))
-	default = []
+  description = "Filters for the events and metrics on the stream subscription"
+  type = list(object({
+    property = string,
+    operator = string,
+    values   = list(string),
+    or       = optional(bool),
+  }))
+  default = []
 }
 variable "pagerduty_host" {
-	description = "Hostname for PagerDuty streaming messages destination"
-	type = string
-	default = ""
+  description = "Hostname for PagerDuty streaming messages destination"
+  type        = string
+  default     = ""
 }
 variable "pagerduty_integration_key" {
-	description = "PagerDuty integration key value for authentication"
-	type = string
-	default = ""
-	sensitive = true
+  description = "PagerDuty integration key value for authentication"
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "pagerduty_metric_exceptions" {
-	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_metric_selections" {
-	description = "Metrics to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "pagerduty_name" {
-	description = "Name of the PagerDuty Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Name of the PagerDuty Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "slack_enabled" {
-	description = "Boolean value indicating enablement of the Slack Subscription Resource"
-	type = string
-	default = ""
+  description = "Boolean value indicating enablement of the Slack Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "slack_event_exceptions" {
-	description = "Events to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "slack_event_selections" {
-	description = "Events to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "slack_filters" {
-	description = "Filters for the events and metrics on the stream subscription"
-	type        = list(object({
-		property = string,
-		operator = string,
-		values = list(string),
-		or = optional(bool),
-	}))
-	default = []
+  description = "Filters for the events and metrics on the stream subscription"
+  type = list(object({
+    property = string,
+    operator = string,
+    values   = list(string),
+    or       = optional(bool),
+  }))
+  default = []
 }
 variable "slack_metric_exceptions" {
-	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "slack_metric_selections" {
-	description = "Metrics to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "slack_name" {
-	description = "Name of the Slack Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Name of the Slack Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "slack_description" {
-	description = "Description of the Slack Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Description of the Slack Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "slack_uri" {
-	description = "URI for the Slack destination for the streaming messages"
-	type = string
-	default = ""
-	sensitive = true
+  description = "URI for the Slack destination for the streaming messages"
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "splunk_access_token" {
-	description = "Credential for Splunk Sink Subscription"
-	type = string
-	default = ""
-	sensitive = true
+  description = "Credential for Splunk Sink Subscription"
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 variable "splunk_description" {
-	description = "Description of the Splunk Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Description of the Splunk Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "splunk_event_exceptions" {
-	description = "Events to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "splunk_event_index" {
-	description = "Event index for the Splunk Sink Source"
-	type = string
-	default = ""
+  description = "Event index for the Splunk Sink Source"
+  type        = string
+  default     = ""
 }
 variable "splunk_event_selections" {
-	description = "Events to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Events to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "splunk_filters" {
-	description = "Filters for the events and metrics on the stream subscription"
-	type        = list(object({
-		property = string,
-		operator = string,
-		values = list(string),
-		or = optional(bool),
-	}))
-	default = []
+  description = "Filters for the events and metrics on the stream subscription"
+  type = list(object({
+    property = string,
+    operator = string,
+    values   = list(string),
+    or       = optional(bool),
+  }))
+  default = []
 }
 variable "splunk_metric_exceptions" {
-	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "splunk_metric_index" {
-	description = "Metric index for the Splunk Sink Source"
-	type = string
-	default = ""
+  description = "Metric index for the Splunk Sink Source"
+  type        = string
+  default     = ""
 }
 variable "splunk_metric_selections" {
-	description = "Metrics to include from the possibilities available to the stream for the Subscription"
-	type = list(string)
-	default = []
+  description = "Metrics to include from the possibilities available to the stream for the Subscription"
+  type        = list(string)
+  default     = []
 }
 variable "splunk_name" {
-	description = "Name of the Splunk Equinix Subscription Resource"
-	type = string
-	default = ""
+  description = "Name of the Splunk Equinix Subscription Resource"
+  type        = string
+  default     = ""
 }
 variable "splunk_source" {
-	description = "Name of the created Splunk Source for the destination of the streaming messages"
-	type = string
-	default = ""
+  description = "Name of the created Splunk Source for the destination of the streaming messages"
+  type        = string
+  default     = ""
 }
 variable "splunk_uri" {
-	description = "URI for the streaming messages to be sent to for Splunk"
-	type = string
-	default = ""
+  description = "URI for the streaming messages to be sent to for Splunk"
+  type        = string
+  default     = ""
 }
 variable "splunk_enabled" {
-	description = "Boolean value indicating enablement of the Splunk Subscription"
-	type = string
-	default = ""
+  description = "Boolean value indicating enablement of the Splunk Subscription"
+  type        = string
+  default     = ""
 }
 variable "stream_description" {
-	description = "Description of the created stream(s) in the module"
-	type = string
+  description = "Description of the created stream(s) in the module"
+  type        = string
 }
 variable "stream_name" {
-	description = "Name (and name prefix) for the created stream(s) in the module"
-	type = string
+  description = "Name (and name prefix) for the created stream(s) in the module"
+  type        = string
 }

--- a/modules/streaming-observability/variables.tf
+++ b/modules/streaming-observability/variables.tf
@@ -1,0 +1,320 @@
+
+variable "datadog_api_key" {
+	description = "API Key for Datadog account"
+	type = string
+	default = ""
+	sensitive = true
+}
+variable "datadog_application_key" {
+	description = "Application Key for Datadog App receiving the streaming messages"
+	type = string
+	default = ""
+	sensitive = true
+}
+variable "datadog_description" {
+	description = "Description of the Datadog Subscription"
+	type = string
+	default = ""
+}
+variable "datadog_enabled" {
+	description = "Boolean value enabling Datadog Subscription"
+	type = string
+	default = ""
+}
+variable "datadog_event_exceptions" {
+	description = "Events to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "datadog_event_selections" {
+	description = "Events to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "datadog_event_uri" {
+	description = "Datadog App URI for receiving streamed events"
+	type = string
+	default = ""
+}
+variable "datadog_filters" {
+	description = "Filters for the Datadog Subscription"
+	type        = list(object({
+		property = string,
+		operator = string,
+		values = list(string),
+		or = optional(bool),
+	}))
+	default = []
+}
+variable "datadog_host" {
+	description = "Datadog Sink Hostname"
+	type = string
+	default = ""
+}
+variable "datadog_metric_exceptions" {
+	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "datadog_metric_selections" {
+	description = "Metrics to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "datadog_metric_uri" {
+	description = "Datadog App URI for receiving streamed metrics"
+	type = string
+	default = ""
+}
+variable "datadog_name" {
+	description = "Name of the Datadog Subscription Equinix Resource"
+	type = string
+	default = ""
+}
+variable "msteams_description" {
+	description = "Description for the MSTeams Subscription Resource"
+	type = string
+	default = ""
+}
+variable "msteams_enabled" {
+	description = "Boolean value enabling MSTeams Sink Subscription"
+	type = string
+	default = ""
+}
+variable "msteams_event_exceptions" {
+	description = "Events to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "msteams_event_selections" {
+	description = "Events to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "msteams_filters" {
+	description = "Filters for the events and metrics on the stream subscription"
+	type        = list(object({
+		property = string,
+		operator = string,
+		values = list(string),
+		or = optional(bool),
+	}))
+	default = []
+}
+variable "msteams_metric_exceptions" {
+	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "msteams_metric_selections" {
+	description = "Metrics to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "msteams_name" {
+	description = "Name of the MSTeams Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "msteams_uri" {
+	description = "URI that the streaming messages will be sent to for MSTeams"
+	type = string
+	default = ""
+	sensitive = true
+}
+variable "pagerduty_alert_uri" {
+	description = "URI for the streaming alerts to be sent to for PagerDuty"
+	type = string
+	default = ""
+}
+variable "pagerduty_change_uri" {
+	description = "URI for the streaming events to be sent to for PagerDuty"
+	type = string
+	default = ""
+}
+variable "pagerduty_description" {
+	description = "Description of the PagerDuty Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "pagerduty_enabled" {
+	description = "Boolean value indicating enablment for the PagerDuty Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "pagerduty_event_exceptions" {
+	description = "Events to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "pagerduty_event_selections" {
+	description = "Events to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "pagerduty_filters" {
+	description = "Filters for the events and metrics on the stream subscription"
+	type        = list(object({
+		property = string,
+		operator = string,
+		values = list(string),
+		or = optional(bool),
+	}))
+	default = []
+}
+variable "pagerduty_host" {
+	description = "Hostname for PagerDuty streaming messages destination"
+	type = string
+	default = ""
+}
+variable "pagerduty_integration_key" {
+	description = "PagerDuty integration key value for authentication"
+	type = string
+	default = ""
+	sensitive = true
+}
+variable "pagerduty_metric_exceptions" {
+	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "pagerduty_metric_selections" {
+	description = "Metrics to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "pagerduty_name" {
+	description = "Name of the PagerDuty Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "slack_enabled" {
+	description = "Boolean value indicating enablement of the Slack Subscription Resource"
+	type = string
+	default = ""
+}
+variable "slack_event_exceptions" {
+	description = "Events to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "slack_event_selections" {
+	description = "Events to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "slack_filters" {
+	description = "Filters for the events and metrics on the stream subscription"
+	type        = list(object({
+		property = string,
+		operator = string,
+		values = list(string),
+		or = optional(bool),
+	}))
+	default = []
+}
+variable "slack_metric_exceptions" {
+	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "slack_metric_selections" {
+	description = "Metrics to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "slack_name" {
+	description = "Name of the Slack Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "slack_description" {
+	description = "Description of the Slack Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "slack_uri" {
+	description = "URI for the Slack destination for the streaming messages"
+	type = string
+	default = ""
+	sensitive = true
+}
+variable "splunk_access_token" {
+	description = "Credential for Splunk Sink Subscription"
+	type = string
+	default = ""
+	sensitive = true
+}
+variable "splunk_description" {
+	description = "Description of the Splunk Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "splunk_event_exceptions" {
+	description = "Events to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "splunk_event_index" {
+	description = "Event index for the Splunk Sink Source"
+	type = string
+	default = ""
+}
+variable "splunk_event_selections" {
+	description = "Events to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "splunk_filters" {
+	description = "Filters for the events and metrics on the stream subscription"
+	type        = list(object({
+		property = string,
+		operator = string,
+		values = list(string),
+		or = optional(bool),
+	}))
+	default = []
+}
+variable "splunk_metric_exceptions" {
+	description = "Metrics to exclude from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "splunk_metric_index" {
+	description = "Metric index for the Splunk Sink Source"
+	type = string
+	default = ""
+}
+variable "splunk_metric_selections" {
+	description = "Metrics to include from the possibilities available to the stream for the Subscription"
+	type = list(string)
+	default = []
+}
+variable "splunk_name" {
+	description = "Name of the Splunk Equinix Subscription Resource"
+	type = string
+	default = ""
+}
+variable "splunk_source" {
+	description = "Name of the created Splunk Source for the destination of the streaming messages"
+	type = string
+	default = ""
+}
+variable "splunk_uri" {
+	description = "URI for the streaming messages to be sent to for Splunk"
+	type = string
+	default = ""
+}
+variable "splunk_enabled" {
+	description = "Boolean value indicating enablement of the Splunk Subscription"
+	type = string
+	default = ""
+}
+variable "stream_description" {
+	description = "Description of the created stream(s) in the module"
+	type = string
+}
+variable "stream_name" {
+	description = "Name (and name prefix) for the created stream(s) in the module"
+	type = string
+}

--- a/modules/streaming-observability/versions.tf
+++ b/modules/streaming-observability/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.5.4"
+  required_providers {
+    equinix = {
+      source  = "equinix/equinix"
+      version = ">= 3.3.0"
+    }
+  }
+}

--- a/tests/uat/uat_sanity_suite_test.go
+++ b/tests/uat/uat_sanity_suite_test.go
@@ -140,7 +140,7 @@ func TestCloudRouter2AzureCreateConnection_PFCR(t *testing.T) {
 	assert.NotNil(t, output)
 }
 
-func  TestCloudRouter2PortRoutingProtocolAndRouteFilterCreateConnection_PFCR(t *testing.T) {
+func TestCloudRouter2PortRoutingProtocolAndRouteFilterCreateConnection_PFCR(t *testing.T) {
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../../tests/examples-without-external-providers/cloud-router-2-port-connection-with-routing-protocols-and-route-filters",
@@ -220,6 +220,78 @@ func TestVirtualDevice2AWSCreateConnection_PFCR(t *testing.T) {
 
 	terraform.InitAndApply(t, terraformOptions)
 	output := terraform.Output(t, terraformOptions, "aws_connection_id")
+	assert.NotNil(t, output)
+}
+
+func TestStreamDatadogSubscription_PFCR(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../../examples/stream-datadog-subscription",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "datadog_subscription")
+	assert.NotNil(t, output)
+}
+
+func TestStreamMSTeamsSubscription_PFCR(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../../examples/stream-msteams-subscription",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "msteams_subscription")
+	assert.NotNil(t, output)
+}
+
+func TestStreamPagerDutySubscription_PFCR(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../../examples/stream-pagerduty-subscription",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "pagerduty_subscription")
+	assert.NotNil(t, output)
+}
+
+func TestStreamSlackSubscription_PFCR(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../../examples/stream-slack-subscription",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "slack_subscription")
+	assert.NotNil(t, output)
+}
+
+func TestStreamSplunkSubscription_PFCR(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../../examples/stream-splunk-subscription",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "splunk_subscription")
+	assert.NotNil(t, output)
+}
+
+func TestStreamMultipleSubscriptionsAndAttachment_PFCR(t *testing.T) {
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../../examples/stream-multiple-subscriptions-with-port-connection-attachment",
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+	output := terraform.Output(t, terraformOptions, "first_stream")
 	assert.NotNil(t, output)
 }
 


### PR DESCRIPTION
* Create Streaming Observability Module
* Add examples for Datadog, MSTeams, Pagerduty, Slack, and Splunk Subscriptions
* Add example for Multiple Subscriptions, Port connection, and Port connection attachment to Streams
* Unit tests added for each example
* Secrets added to GHA and Workflow updated; Vault additions made as well