### PR TITLE
fix: various UAT test cases

### DIFF
--- a/.github/workflows/terratests-uat-suite.yaml
+++ b/.github/workflows/terratests-uat-suite.yaml
@@ -175,9 +175,10 @@ jobs:
           echo $TEST_DATA_UAT_CLOUD_ROUTER_2_AWS_CONNECTION >> "./tests/examples-without-external-providers/cloud-router-2-aws-connection/terraform.tfvars.json"
           echo $TEST_DATA_UAT_CLOUD_ROUTER_2_AZURE_CONNECTION >> "./tests/examples-without-external-providers/cloud-router-2-azure-connection/terraform.tfvars.json"
           echo $TEST_DATA_UAT_CLOUD_ROUTER_2_PORT_ROUTING_PROTOCOL_AND_ROUTE_FILTER_CONNECTION  >> "./tests/examples-without-external-providers/cloud-router-2-port-connection-with-routing-protocols-and-route-filters/terraform.tfvars.json"
+          echo $TEST_DATA_UAT_CLOUD_ROUTER_2_VIRTUAL_DEVICE_CONNECTION >> "./tests/examples-without-external-providers/cloud-router-2-virtual-device-connection/terraform.tfvars.json"
+
           echo $TEST_DATA_UAT_CLOUD_ROUTER_2_SERVICE_PROFILE_CONNECTION >> "./examples/cloud-router-2-service-profile-connection/terraform.tfvars.json"
           echo $TEST_DATA_UAT_CLOUD_ROUTER_2_WAN_CONNECTION >> "./examples/cloud-router-2-wan-connection/terraform.tfvars.json"
-          echo $TEST_DATA_UAT_CLOUD_ROUTER_2_VIRTUAL_DEVICE_CONNECTION >> "./examples/cloud-router-2-virtual-device-connection/terraform.tfvars.json"
           
           echo $TEST_DATA_UAT_STREAM_DATADOG_SUBSCRIPTION >> "./examples/stream-datadog-subscription/terraform.tfvars.json"
           echo $TEST_DATA_UAT_STREAM_MSTEAMS_SUBSCRIPTION >> "./examples/stream-msteams-subscription/terraform.tfvars.json"

--- a/examples/stream-grafana-subscription/main.tf
+++ b/examples/stream-grafana-subscription/main.tf
@@ -19,5 +19,5 @@ module "stream_grafana_subscription" {
   grafana_metric_selections = var.grafana_metric_selections
   grafana_event_uri         = var.grafana_event_uri
   grafana_metric_uri        = var.grafana_metric_uri
-  grafana_format            = var.grafana_format
+  grafana_api_key           = var.grafana_api_key
 }

--- a/examples/stream-grafana-subscription/terraform.tfvars.example
+++ b/examples/stream-grafana-subscription/terraform.tfvars.example
@@ -20,4 +20,3 @@ grafana_metric_exceptions = ["equinix.fabric.connection.*"]
 grafana_metric_selections = ["equinix.fabric.port.*"]
 grafana_event_uri         = "<grafana_event_uri>"
 grafana_metric_uri        = "<grafana_metric_uri>"
-grafana_format            = "<grafana_format>"

--- a/examples/stream-grafana-subscription/variables.tf
+++ b/examples/stream-grafana-subscription/variables.tf
@@ -73,6 +73,7 @@ variable "grafana_format" {
   description = "Format for grafana payload"
   type        = string
   default     = null
+  deprecated  = "No longer required to be provided"
 }
 variable "grafana_filters" {
   description = "Filters for the Grafana Subscription"
@@ -85,3 +86,8 @@ variable "grafana_filters" {
   default = []
 }
 
+variable "grafana_api_key" {
+  description = "API Key for Grafana account"
+  type        = string
+  sensitive   = true
+}

--- a/modules/streaming-observability/main.tf
+++ b/modules/streaming-observability/main.tf
@@ -258,9 +258,14 @@ resource "equinix_fabric_stream_subscription" "grafana" {
   sink = {
     type = "WEBHOOK"
     settings = {
-      format     = var.grafana_format
+      format     = "OPENTELEMETRY"
       event_uri  = var.grafana_event_uri != "" ? var.grafana_event_uri : null
       metric_uri = var.grafana_metric_uri != "" ? var.grafana_metric_uri : null
+    }
+
+    credential = {
+        type    = "API_KEY"
+        api_key = var.grafana_api_key
     }
   }
 }

--- a/modules/streaming-observability/variables.tf
+++ b/modules/streaming-observability/variables.tf
@@ -472,6 +472,7 @@ variable "grafana_format" {
   description = "Format for grafana payload"
   type        = string
   default     = "JSON"
+  deprecated = "No longer required to be provided"
 }
 variable "grafana_metric_uri" {
   description = "URI endpoint for grafana metrics"
@@ -483,4 +484,10 @@ variable "project_id" {
   description = "Project ID where the streams will be created"
   type        = string
   default     = ""
+}
+variable "grafana_api_key" {
+  description = "API Key for Grafana account"
+  type        = string
+  default     = ""
+  sensitive   = true
 }


### PR DESCRIPTION
Fixed tests:
* TestStreamGrafanaSubscription_PFCR
* TestCloudRouter2VirtualDeviceCreateConnection_PFCR

<img width="732" height="77" alt="Screenshot 2026-06-26 at 4 45 19 PM" src="https://github.com/user-attachments/assets/17a0f511-00ca-41bf-8ecc-226e941e5cc0" />

Note: Fixed the missing variable issue on `TestCloudRouter2VirtualDeviceCreateConnection_PFCR`, but the server is having issues, require further investigation

```
[
 {
  "errorCode": "EQ-4014121",
  "errorMessage": "System is unable to process the request at this time due to an error from Network Edge API call.",
  "details": "Virtual device configuration not returned by Network Edge. Please open a ticket with Network Edge Support team. A call to '/ne/i1/l2/connections/configurations' failed.",
  "correlationId": "ouviFlpQ13EK7uIjJtnB7nEJN",
  "additionalInfo": [
   {
    "property": "NE response httpStatusCode",
    "reason": "500"
   },
   {
    "property": "NE response errorCode",
    "reason": "EQ-4014102"
   },
   {
    "property": "NE response help",
    "reason": "https://<domain.name>/help/error/EQ-4014102"
   },
   {
    "property": "NE response additionalInfo",
    "reason": "[ErrorResponse.AdditionalInfo(property=null, reason=null, errorMessageKey=null, detailsKey=null)]"
   }
  ]
 }
]
```